### PR TITLE
Tests

### DIFF
--- a/source/tests/cppexpose-test/DirectValueTest.cpp
+++ b/source/tests/cppexpose-test/DirectValueTest.cpp
@@ -103,6 +103,17 @@ TEST_F(DirectValueTest, arraySet)
     ASSERT_EQ(10, val.getElement(0));
 }
 
+TEST_F(DirectValueTest, constSet)
+{
+    auto val = DirectValue<const bool>(false);
+
+    ASSERT_FALSE(val.value());
+
+    val.setValue(true);
+
+    ASSERT_FALSE(val.value());
+}
+
 TEST_F(DirectValueTest, typesBool)
 {
     TypeTester<bool> tester;

--- a/source/tests/cppexpose-test/PropertyTest.cpp
+++ b/source/tests/cppexpose-test/PropertyTest.cpp
@@ -2,6 +2,8 @@
 
 #include <gmock/gmock.h>
 
+#include <array>
+
 #include <cppexpose/reflection/Property.h>
 
 using namespace cppexpose;
@@ -93,6 +95,24 @@ TEST_F(PropertyTest, boolSet)
     
     ASSERT_FALSE(prop->toBool());
     ASSERT_TRUE(callbackVar);
+}
+
+TEST_F(PropertyTest, ArraySet)
+{
+    PropertyGroup propGroup;
+
+    std::array<int, 4> value{1,2,3,4};
+
+    auto getter = [&value](){return value;};
+    auto setter = [&value](const std::array<int, 4> & arr){value = arr;};
+
+    auto elementGetter = [&value](const int & index) -> int {return value[index];};
+    auto elementSetter = [&value](const int & index, const int & val){value[index] = val;};
+
+    auto prop = new Property<std::array<int, 4>>(&propGroup, "Property", getter, setter, elementGetter, elementSetter);
+
+    prop->setElement(0, 10);
+    ASSERT_EQ(10, prop->getElement(0));
 }
 
 TEST_F(PropertyTest, stringSet)

--- a/source/tests/cppexpose-test/StoredValueTest.cpp
+++ b/source/tests/cppexpose-test/StoredValueTest.cpp
@@ -120,7 +120,7 @@ TEST_F(StoredValueTest, arraySet)
     auto store = StoredValue<std::array<int, 4>>(getter, setter, elementGetter, elementSetter);
 
 
-   store.setElement(0, 10);
+    store.setElement(0, 10);
     ASSERT_EQ(value[0], 10);
 }
 


### PR DESCRIPTION
This adds tests for Arrays in Properties as well as constness in DirectValues.
Since StoredValues (and by extension Properties) need to supply their own access methods, it is impossible to compile non const-correct code for those.
As to Variants: they are not templated but instead use DirectValues internally. As such the constness test for DirectValues should suffice.
