### PR TITLE
Remove unreachable code

### DIFF
--- a/source/cppexpose/include/cppexpose/typed/TypedEnum.hpp
+++ b/source/cppexpose/include/cppexpose/typed/TypedEnum.hpp
@@ -74,13 +74,10 @@ bool TypedEnum<T, BASE>::fromVariant(const Variant & variant)
 {
     if (variant.hasType<T>()) {
         this->setValue(variant.value<T>());
-        return true;
     } else {
         this->setValue((T)variant.value<int>());
-        return true;
     }
-
-    return false;
+    return true;
 }
 
 template <typename T, typename BASE>

--- a/source/cppexpose/include/cppexpose/typed/TypedEnum.hpp
+++ b/source/cppexpose/include/cppexpose/typed/TypedEnum.hpp
@@ -77,6 +77,7 @@ bool TypedEnum<T, BASE>::fromVariant(const Variant & variant)
     } else {
         this->setValue((T)variant.value<int>());
     }
+
     return true;
 }
 


### PR DESCRIPTION
This causes a warning in code using cppexpose with warning level 4 on MSVC.

BTW, why is there
1. a c-style cast?
2. no check if variant is of type int?