### PR TITLE
Memory management with std::unique_ptr

### DIFF
--- a/source/cppexpose/include/cppexpose/function/AbstractFunction.h
+++ b/source/cppexpose/include/cppexpose/function/AbstractFunction.h
@@ -3,6 +3,7 @@
 
 
 #include <vector>
+#include <memory>
 
 #include <cppexpose/cppexpose_api.h>
 
@@ -39,7 +40,7 @@ public:
     *  @return
     *    New function object pointing to the same function. Has to be deleted by the caller.
     */
-    virtual AbstractFunction * clone() = 0;
+    virtual std::unique_ptr<AbstractFunction> clone() = 0;
 
     /**
     *  @brief

--- a/source/cppexpose/include/cppexpose/function/Function.h
+++ b/source/cppexpose/include/cppexpose/function/Function.h
@@ -3,6 +3,7 @@
 
 
 #include <vector>
+#include <memory>
 
 #include <cppexpose/cppexpose_api.h>
 
@@ -35,7 +36,7 @@ public:
     *  @param[in] func
     *    Function object (can be null)
     */
-    Function(AbstractFunction * func = nullptr);
+    Function(std::unique_ptr<AbstractFunction> && func = nullptr);
 
     /**
     *  @brief
@@ -50,7 +51,7 @@ public:
     *  @brief
     *    Destructor
     */
-    ~Function();
+    virtual ~Function();
 
     /**
     *  @brief
@@ -78,7 +79,7 @@ public:
 
 
 protected:
-    AbstractFunction * m_func; ///< Function implementation
+    std::unique_ptr<AbstractFunction> m_func; ///< Function implementation
 };
 
 

--- a/source/cppexpose/include/cppexpose/function/MemberFunction.h
+++ b/source/cppexpose/include/cppexpose/function/MemberFunction.h
@@ -44,7 +44,7 @@ public:
     virtual ~MemberFunction();
 
     // Virtual AbstractFunction interface
-    virtual AbstractFunction * clone() override;
+    virtual std::unique_ptr<AbstractFunction> clone() override;
     virtual Variant call(const std::vector<Variant> & args) override;
 
 

--- a/source/cppexpose/include/cppexpose/function/MemberFunction.inl
+++ b/source/cppexpose/include/cppexpose/function/MemberFunction.inl
@@ -2,6 +2,9 @@
 #pragma once
 
 
+#include <cppassist/memory/make_unique.h>
+
+
 namespace cppexpose
 {
 
@@ -19,9 +22,9 @@ MemberFunction<T, RET, Arguments...>::~MemberFunction()
 }
 
 template <class T, typename RET, typename... Arguments>
-AbstractFunction * MemberFunction<T, RET, Arguments...>::clone()
+std::unique_ptr<AbstractFunction> MemberFunction<T, RET, Arguments...>::clone()
 {
-    return new MemberFunction<T, RET, Arguments...>(m_obj, m_func);
+    return cppassist::make_unique<MemberFunction<T, RET, Arguments...>>(m_obj, m_func);
 }
 
 template <class T, typename RET, typename... Arguments>

--- a/source/cppexpose/include/cppexpose/function/StaticFunction.h
+++ b/source/cppexpose/include/cppexpose/function/StaticFunction.h
@@ -42,7 +42,7 @@ public:
     virtual ~StaticFunction();
 
     // Virtual AbstractFunction interface
-    virtual AbstractFunction * clone() override;
+    virtual std::unique_ptr<AbstractFunction> clone() override;
     virtual Variant call(const std::vector<Variant> & args) override;
 
 

--- a/source/cppexpose/include/cppexpose/function/StaticFunction.inl
+++ b/source/cppexpose/include/cppexpose/function/StaticFunction.inl
@@ -1,5 +1,6 @@
 
 #pragma once
+#include <cppassist/memory/make_unique.inl>
 
 
 namespace cppexpose
@@ -18,9 +19,9 @@ StaticFunction<RET, Arguments...>::~StaticFunction()
 }
 
 template <typename RET, typename... Arguments>
-AbstractFunction * StaticFunction<RET, Arguments...>::clone()
+std::unique_ptr<AbstractFunction> StaticFunction<RET, Arguments...>::clone()
 {
-    return new StaticFunction<RET, Arguments...>(m_func);
+    return cppassist::make_unique<StaticFunction<RET, Arguments...>>(m_func);
 }
 
 template <typename RET, typename... Arguments>

--- a/source/cppexpose/include/cppexpose/plugin/AbstractGenericComponent.h
+++ b/source/cppexpose/include/cppexpose/plugin/AbstractGenericComponent.h
@@ -2,6 +2,8 @@
 #pragma once
 
 
+#include <memory>
+
 #include <cppexpose/plugin/AbstractComponent.h>
 
 
@@ -43,7 +45,7 @@ public:
     *  @return
     *    New instance
     */
-    virtual BaseType * createInstance() const = 0;
+    virtual std::unique_ptr<BaseType> createInstance() const = 0;
 };
 
 

--- a/source/cppexpose/include/cppexpose/plugin/ComponentManager.h
+++ b/source/cppexpose/include/cppexpose/plugin/ComponentManager.h
@@ -240,7 +240,7 @@ protected:
     std::vector<std::string>                              m_paths;               ///< Plugin paths (all)
     std::vector<std::string>                              m_pathsInternal;       ///< Plugin paths (internal)
     std::vector<std::string>                              m_pathsUser;           ///< Plugin paths (user defined)
-    std::vector<AbstractComponent *>                      m_components;          ///< Available components
+    std::vector<AbstractComponent *>                      m_components;          ///< Available components, statically initialized once per component class via the COMPONENT macro
     std::map<std::string, std::unique_ptr<PluginLibrary>> m_librariesByFilePath; ///< Available components by path
     std::map<std::string, AbstractComponent *>            m_componentsByName;    ///< Available components by name
 };

--- a/source/cppexpose/include/cppexpose/plugin/ComponentManager.h
+++ b/source/cppexpose/include/cppexpose/plugin/ComponentManager.h
@@ -58,9 +58,21 @@ public:
 
     /**
     *  @brief
+    *    Copy constructor (deleted)
+    */
+    ComponentManager(const ComponentManager &) = delete;
+
+    /**
+    *  @brief
     *    Destructor
     */
     virtual ~ComponentManager();
+
+    /**
+    *  @brief
+    *     Copy assignment operator (deleted)
+    */
+    ComponentManager & operator=(const ComponentManager &) = delete;
 
     /**
     *  @brief
@@ -225,12 +237,12 @@ protected:
 
 
 protected:
-    std::vector<std::string>                   m_paths;               ///< Plugin paths (all)
-    std::vector<std::string>                   m_pathsInternal;       ///< Plugin paths (internal)
-    std::vector<std::string>                   m_pathsUser;           ///< Plugin paths (user defined)
-    std::vector<AbstractComponent *>           m_components;          ///< Available components
-    std::map<std::string, PluginLibrary *>     m_librariesByFilePath; ///< Available components by path
-    std::map<std::string, AbstractComponent *> m_componentsByName;    ///< Available components by name
+    std::vector<std::string>                              m_paths;               ///< Plugin paths (all)
+    std::vector<std::string>                              m_pathsInternal;       ///< Plugin paths (internal)
+    std::vector<std::string>                              m_pathsUser;           ///< Plugin paths (user defined)
+    std::vector<AbstractComponent *>                      m_components;          ///< Available components
+    std::map<std::string, std::unique_ptr<PluginLibrary>> m_librariesByFilePath; ///< Available components by path
+    std::map<std::string, AbstractComponent *>            m_componentsByName;    ///< Available components by name
 };
 
 

--- a/source/cppexpose/include/cppexpose/plugin/GenericComponent.h
+++ b/source/cppexpose/include/cppexpose/plugin/GenericComponent.h
@@ -33,7 +33,7 @@ public:
     virtual ~GenericComponent();
 
     // Virtual AbstractGenericComponent<BaseType> interface
-    virtual BaseType * createInstance() const override;
+    virtual std::unique_ptr<BaseType> createInstance() const override;
 };
 
 

--- a/source/cppexpose/include/cppexpose/plugin/GenericComponent.inl
+++ b/source/cppexpose/include/cppexpose/plugin/GenericComponent.inl
@@ -2,6 +2,9 @@
 #pragma once
 
 
+#include <cppassist/memory/make_unique.h>
+
+
 namespace cppexpose
 {
 
@@ -18,9 +21,9 @@ GenericComponent<Type, BaseType>::~GenericComponent()
 }
 
 template <typename Type, typename BaseType>
-BaseType * GenericComponent<Type, BaseType>::createInstance() const
+std::unique_ptr<BaseType> GenericComponent<Type, BaseType>::createInstance() const
 {
-    return new Type();
+    return cppassist::make_unique<Type>();
 }
 
 

--- a/source/cppexpose/include/cppexpose/reflection/AbstractProperty.h
+++ b/source/cppexpose/include/cppexpose/reflection/AbstractProperty.h
@@ -18,17 +18,6 @@ class Object;
 
 /**
 *  @brief
-*    Defines the ownership for a property or object
-*/
-enum class PropertyOwnership
-{
-    None = 0 ///< The property is owner by itself (or outside)
-  , Parent   ///< The property is owned by its parent
-};
-
-
-/**
-*  @brief
 *    Base class for properties
 */
 class CPPEXPOSE_API AbstractProperty : public AbstractTyped
@@ -207,7 +196,7 @@ protected:
     *    Do not set m_parent before calling this function, otherwise
     *    the property might be rejected when added to the parent.
     */
-    void initProperty(const std::string & name, Object * parent, PropertyOwnership ownership);
+    void initProperty(const std::string & name, Object * parent);
 
     /**
     *  @brief

--- a/source/cppexpose/include/cppexpose/reflection/DynamicProperty.inl
+++ b/source/cppexpose/include/cppexpose/reflection/DynamicProperty.inl
@@ -11,7 +11,7 @@ template <typename... Args>
 DynamicProperty<T, BASE>::DynamicProperty(const std::string & name, Object * parent, Args&&... args)
 : DirectValue<T, BASE>(std::forward<Args>(args)...)
 {
-    this->initProperty(name, parent, PropertyOwnership::None);
+    this->initProperty(name, parent);
 }
 
 template <typename T, typename BASE>

--- a/source/cppexpose/include/cppexpose/reflection/Method.h
+++ b/source/cppexpose/include/cppexpose/reflection/Method.h
@@ -30,7 +30,7 @@ public:
     *  @param[in] parent
     *    Parent object (can be null)
     */
-    Method(AbstractFunction * func, Object * parent = nullptr);
+    Method(std::unique_ptr<AbstractFunction> && func, Object * parent = nullptr);
 
     /**
     *  @brief
@@ -43,7 +43,7 @@ public:
     *  @param[in] parent
     *    Parent object (can be null)
     */
-    Method(const std::string & name, AbstractFunction * func, Object * parent = nullptr);
+    Method(const std::string & name, std::unique_ptr<AbstractFunction> && func, Object * parent = nullptr);
 
     /**
     *  @brief

--- a/source/cppexpose/include/cppexpose/reflection/Object.h
+++ b/source/cppexpose/include/cppexpose/reflection/Object.h
@@ -55,14 +55,29 @@ public:
     */
     Object(const std::string & name);
 
+    /**
+    *  @brief
+    *    Copy constructor (deleted)
+    *
+    *  @param[in]
+    *    Object to copy from
+    */
     Object(const Object &) = delete;
-    Object & operator=(const Object &) = delete;
 
     /**
     *  @brief
     *    Destructor
     */
     virtual ~Object();
+
+    /**
+    *  @brief
+    *    Copy assignment operator (deleted)
+    *
+    *  @param[in]
+    *    Object to copy from
+    */
+    Object & operator=(const Object &) = delete;
 
     /**
     *  @brief
@@ -151,8 +166,6 @@ public:
     *
     *  @param[in] property
     *    Property (must NOT be null!)
-    *  @param[in] ownership
-    *    Property ownership
     *
     *  @return
     *    'true' if the property has been added to the object, else 'false'
@@ -163,12 +176,26 @@ public:
     *    The name of the property must be valid and unique to the object,
     *    also the property must not belong to any other object already.
     *    Otherwise, the property will not be added to the object.
-    *
-    *    If ownership is set to PropertyOwnership::Parent, the object
-    *    takes the ownership over the specified property, so the property
-    *    will be deleted together with the object in its destructor.
     */
     bool addProperty(AbstractProperty * property);
+
+    /**
+    *  @brief
+    *    Add property to object
+    *
+    *  @param[in] property
+    *    Property (must NOT be null!)
+    *
+    *  @return
+    *    'true' if the property has been added to the object, else 'false'
+    *
+    *  @remarks
+    *    Adds the given property to the object.
+    *
+    *    The name of the property must be valid and unique to the object,
+    *    also the property must not belong to any other object already.
+    *    Otherwise, the property will not be added to the object.
+    */
     bool addProperty(std::unique_ptr<AbstractProperty> && property);
 
     /**

--- a/source/cppexpose/include/cppexpose/reflection/Object.h
+++ b/source/cppexpose/include/cppexpose/reflection/Object.h
@@ -55,6 +55,9 @@ public:
     */
     Object(const std::string & name);
 
+    Object(const Object &) = delete;
+    Object & operator=(const Object &) = delete;
+
     /**
     *  @brief
     *    Destructor
@@ -165,7 +168,8 @@ public:
     *    takes the ownership over the specified property, so the property
     *    will be deleted together with the object in its destructor.
     */
-    bool addProperty(AbstractProperty * property, PropertyOwnership ownership = PropertyOwnership::None);
+    bool addProperty(AbstractProperty * property);
+    bool addProperty(std::unique_ptr<AbstractProperty> && property);
 
     /**
     *  @brief
@@ -181,31 +185,9 @@ public:
     *    If the specified property does not belong to the object,
     *    this function will do nothing and return 'false'.
     *
-    *    If ownership of the property is set to PropertyOwnership::Parent,
-    *    the object will release its ownership over the property and
-    *    transfer it back to the caller. The property will not be deleted!
+    *    If the object has ownership of the property, it will be deleted.
     */
     bool removeProperty(AbstractProperty * property);
-
-    /**
-    *  @brief
-    *    Destroy property
-    *
-    *  @param[in] property
-    *    Property (must NOT be null!)
-    *
-    *  @return
-    *    'true' if the property has been destroyed, else 'false'
-    *
-    *  @remarks
-    *    This function destroys the specified property from the object.
-    *    It can only be used on properties which are owned by the object,
-    *    e.g., properties created by createDynamicProperty or added
-    *    with PropertyOwnership::Parent. Properties which are not owned by
-    *    the object must be deleted by other means, they will automatically
-    *    remove themselves from the object on destruction.
-    */
-    bool destroyProperty(AbstractProperty * property);
 
     //@{
     /**
@@ -324,7 +306,7 @@ protected:
     std::string                                         m_className;         ///< Class name for this object (default: "Object")
     std::vector<AbstractProperty *>                     m_properties;        ///< List of properties in the object
     std::unordered_map<std::string, AbstractProperty *> m_propertiesMap;     ///< Map of names and properties
-    std::vector<AbstractProperty *>                     m_managedProperties; ///< Property that are owned by the object
+    std::vector<std::unique_ptr<AbstractProperty>>      m_managedProperties; ///< Property that are owned by the object
     std::vector<Method>                                 m_functions;         ///< List of exported functions
 };
 

--- a/source/cppexpose/include/cppexpose/reflection/Object.h
+++ b/source/cppexpose/include/cppexpose/reflection/Object.h
@@ -250,7 +250,7 @@ public:
     virtual bool isObject() const override;
 
     // Virtual AbstractTyped interface
-    virtual AbstractTyped * clone() const override;
+    virtual std::unique_ptr<AbstractTyped> clone() const override;
     virtual const std::type_info & type() const override;
     virtual std::string typeName() const override;
     virtual bool isReadOnly() const override;

--- a/source/cppexpose/include/cppexpose/reflection/Object.inl
+++ b/source/cppexpose/include/cppexpose/reflection/Object.inl
@@ -40,8 +40,8 @@ void Object::addFunction(const std::string & name, RET (*fn)(Arguments...))
 template <class T, typename RET, typename... Arguments>
 void Object::addFunction(const std::string & name, T * obj, RET (T::*fn)(Arguments...))
 {
-    AbstractFunction * func = new MemberFunction<T, RET, Arguments...>(obj, fn);
-    m_functions.push_back(Method(name, func));
+    auto func = cppassist::make_unique<MemberFunction<T, RET, Arguments...>>(obj, fn);
+    m_functions.push_back(Method(name, std::move(func)));
 }
 
 

--- a/source/cppexpose/include/cppexpose/reflection/Object.inl
+++ b/source/cppexpose/include/cppexpose/reflection/Object.inl
@@ -33,8 +33,8 @@ DynamicProperty<T> * Object::createDynamicProperty(const std::string & name, con
 template <typename RET, typename... Arguments>
 void Object::addFunction(const std::string & name, RET (*fn)(Arguments...))
 {
-    AbstractFunction * func = new StaticFunction<RET, Arguments...>(fn);
-    m_functions.push_back(Method(name, func));
+    auto func = cppassist::make_unique<StaticFunction<RET, Arguments...>>(fn);
+    m_functions.push_back(Method(name, std::move(func)));
 }
 
 template <class T, typename RET, typename... Arguments>

--- a/source/cppexpose/include/cppexpose/reflection/Object.inl
+++ b/source/cppexpose/include/cppexpose/reflection/Object.inl
@@ -20,11 +20,12 @@ DynamicProperty<T> * Object::createDynamicProperty(const std::string & name, con
     }
 
     // Create property and add it to the object
-    auto * property = new DynamicProperty<T>(name, nullptr, value);
-    this->addProperty(property, PropertyOwnership::Parent);
+    auto property = std::make_unique<DynamicProperty<T>>(name, nullptr, value);
+    auto propertyPtr = property.get();
+    this->addProperty(std::move(property));
 
     // Return property
-    return property;
+    return propertyPtr;
 }
 
 template <typename RET, typename... Arguments>

--- a/source/cppexpose/include/cppexpose/reflection/Object.inl
+++ b/source/cppexpose/include/cppexpose/reflection/Object.inl
@@ -2,6 +2,8 @@
 #pragma once
 
 
+#include <cppassist/memory/make_unique.h>
+
 #include <cppexpose/function/StaticFunction.h>
 #include <cppexpose/function/MemberFunction.h>
 
@@ -20,7 +22,7 @@ DynamicProperty<T> * Object::createDynamicProperty(const std::string & name, con
     }
 
     // Create property and add it to the object
-    auto property = std::make_unique<DynamicProperty<T>>(name, nullptr, value);
+    auto property = cppassist::make_unique<DynamicProperty<T>>(name, nullptr, value);
     auto propertyPtr = property.get();
     this->addProperty(std::move(property));
 

--- a/source/cppexpose/include/cppexpose/reflection/Property.inl
+++ b/source/cppexpose/include/cppexpose/reflection/Property.inl
@@ -14,7 +14,7 @@ template <typename... Args>
 Property<T, BASE>::Property(const std::string & name, Object * parent, Args&&... args)
 : StoredValue<T, BASE>(std::forward<Args>(args)...)
 {
-    this->initProperty(name, parent, PropertyOwnership::None);
+    this->initProperty(name, parent);
 }
 
 template <typename T, typename BASE>

--- a/source/cppexpose/include/cppexpose/scripting/ScriptContext.h
+++ b/source/cppexpose/include/cppexpose/scripting/ScriptContext.h
@@ -47,7 +47,7 @@ public:
     *  @param[in] backend
     *    Scripting backend (must NOT be null)
     */
-    ScriptContext(AbstractScriptBackend * backend);
+    ScriptContext(std::unique_ptr<AbstractScriptBackend> && backend);
 
     /**
     *  @brief
@@ -98,8 +98,8 @@ public:
 
 
 protected:
-    AbstractScriptBackend * m_backend;      ///< Scripting backend (can be null)
-    Object                * m_globalObject; ///< Global object that is exposed to the scripting environment (can be null)
+    std::unique_ptr<AbstractScriptBackend> m_backend;      ///< Scripting backend (can be null)
+    Object                               * m_globalObject; ///< Global object that is exposed to the scripting environment (can be null)
 };
 
 

--- a/source/cppexpose/include/cppexpose/scripting/example/TreeNode.h
+++ b/source/cppexpose/include/cppexpose/scripting/example/TreeNode.h
@@ -96,9 +96,9 @@ public:
 
 
 protected:
-    int        m_id;    ///< ID of the node
-    TreeNode * m_left;  ///< Left child node (can be null)
-    TreeNode * m_right; ///< Right child node (can be null)
+    int        m_id;                   ///< ID of the node
+    std::unique_ptr<TreeNode> m_left;  ///< Left child node (can be null)
+    std::unique_ptr<TreeNode> m_right; ///< Right child node (can be null)
 };
 
 

--- a/source/cppexpose/include/cppexpose/signal/Connection.h
+++ b/source/cppexpose/include/cppexpose/signal/Connection.h
@@ -122,6 +122,8 @@ protected:
     */
     struct State
     {
+        State(const AbstractSignal * signal, Id id);
+
         const AbstractSignal * signal;  ///< Source signal
         Id                     id;      ///< Connection ID
     };

--- a/source/cppexpose/include/cppexpose/typed/AbstractTyped.hh
+++ b/source/cppexpose/include/cppexpose/typed/AbstractTyped.hh
@@ -3,6 +3,7 @@
 
 
 #include <string>
+#include <memory>
 
 #include <cppexpose/typed/TypeInterface.h>
 
@@ -37,7 +38,7 @@ public:
     *  @return
     *    Pointer to the cloned value
     */
-    virtual AbstractTyped * clone() const = 0;
+    virtual std::unique_ptr<AbstractTyped> clone() const = 0;
 
     /**
     *  @brief

--- a/source/cppexpose/include/cppexpose/typed/DirectValueArray.hh
+++ b/source/cppexpose/include/cppexpose/typed/DirectValueArray.hh
@@ -43,7 +43,7 @@ public:
     virtual ~DirectValueArray();
 
     // Virtual AbstractTyped interface
-    virtual AbstractTyped * clone() const override;
+    virtual std::unique_ptr<AbstractTyped> clone() const override;
 
     // Virtual Typed<T> interface
     virtual T value() const override;
@@ -91,7 +91,7 @@ public:
     virtual ~DirectValueArray();
 
     // Virtual AbstractTyped interface
-    virtual AbstractTyped * clone() const override;
+    virtual std::unique_ptr<AbstractTyped> clone() const override;
     virtual bool isReadOnly() const override;
 
     // Virtual Typed<T> interface

--- a/source/cppexpose/include/cppexpose/typed/DirectValueArray.inl
+++ b/source/cppexpose/include/cppexpose/typed/DirectValueArray.inl
@@ -24,9 +24,9 @@ DirectValueArray<T, BASE>::~DirectValueArray()
 }
 
 template <typename T, typename BASE>
-AbstractTyped * DirectValueArray<T, BASE>::clone() const
+std::unique_ptr<AbstractTyped> DirectValueArray<T, BASE>::clone() const
 {
-    return new DirectValueArray<T, AbstractTyped>(m_value);
+    return cppassist::make_unique<DirectValueArray<T, AbstractTyped>>(m_value);
 }
 
 template <typename T, typename BASE>
@@ -86,9 +86,9 @@ DirectValueArray<const T, BASE>::~DirectValueArray()
 }
 
 template <typename T, typename BASE>
-AbstractTyped * DirectValueArray<const T, BASE>::clone() const
+std::unique_ptr<AbstractTyped> DirectValueArray<const T, BASE>::clone() const
 {
-    return new DirectValueArray<const T, AbstractTyped>(this->m_value);
+    return cppassist::make_unique<DirectValueArray<const T, AbstractTyped>>(this->m_value);
 }
 
 template <typename T, typename BASE>

--- a/source/cppexpose/include/cppexpose/typed/DirectValueSingle.hh
+++ b/source/cppexpose/include/cppexpose/typed/DirectValueSingle.hh
@@ -39,7 +39,7 @@ public:
     virtual ~DirectValueSingle();
 
     // Virtual AbstractTyped interface
-    virtual AbstractTyped * clone() const override;
+    virtual std::unique_ptr<AbstractTyped> clone() const override;
 
     // Virtual Typed<T> interface
     virtual T value() const override;
@@ -83,7 +83,7 @@ public:
     virtual ~DirectValueSingle();
 
     // Virtual AbstractTyped interface
-    virtual AbstractTyped * clone() const override;
+    virtual std::unique_ptr<AbstractTyped> clone() const override;
     virtual bool isReadOnly() const override;
 
     // Virtual Typed<T> interface

--- a/source/cppexpose/include/cppexpose/typed/DirectValueSingle.inl
+++ b/source/cppexpose/include/cppexpose/typed/DirectValueSingle.inl
@@ -2,6 +2,9 @@
 #pragma once
 
 
+#include <cppassist/memory/make_unique.h>
+
+
 namespace cppexpose
 {
 
@@ -24,9 +27,9 @@ DirectValueSingle<T, BASE>::~DirectValueSingle()
 }
 
 template <typename T, typename BASE>
-AbstractTyped * DirectValueSingle<T, BASE>::clone() const
+std::unique_ptr<AbstractTyped> DirectValueSingle<T, BASE>::clone() const
 {
-    return new DirectValueSingle<T, AbstractTyped>(m_value);
+    return cppassist::make_unique<DirectValueSingle<T, AbstractTyped>>(m_value);
 }
 
 template <typename T, typename BASE>
@@ -73,9 +76,9 @@ DirectValueSingle<const T, BASE>::~DirectValueSingle()
 }
 
 template <typename T, typename BASE>
-AbstractTyped * DirectValueSingle<const T, BASE>::clone() const
+std::unique_ptr<AbstractTyped> DirectValueSingle<const T, BASE>::clone() const
 {
-    return new DirectValueSingle<const T, AbstractTyped>(this->m_value);
+    return cppassist::make_unique<DirectValueSingle<const T, AbstractTyped>>(this->m_value);
 }
 
 template <typename T, typename BASE>

--- a/source/cppexpose/include/cppexpose/typed/StoredValueArray.hh
+++ b/source/cppexpose/include/cppexpose/typed/StoredValueArray.hh
@@ -84,7 +84,7 @@ public:
     virtual ~StoredValueArray();
 
     // Virtual AbstractTyped interface
-    virtual AbstractTyped * clone() const override;
+    virtual std::unique_ptr<AbstractTyped> clone() const override;
 
     // Virtual Typed<T> interface
     virtual T value() const override;
@@ -172,7 +172,7 @@ public:
     virtual ~StoredValueArray();
 
     // Virtual AbstractTyped interface
-    virtual AbstractTyped * clone() const override;
+    virtual std::unique_ptr<AbstractTyped> clone() const override;
     virtual bool isReadOnly() const override;
 
     // Virtual Typed<T> interface

--- a/source/cppexpose/include/cppexpose/typed/StoredValueArray.inl
+++ b/source/cppexpose/include/cppexpose/typed/StoredValueArray.inl
@@ -63,9 +63,9 @@ StoredValueArray<T, BASE>::~StoredValueArray()
 }
 
 template <typename T, typename BASE>
-AbstractTyped * StoredValueArray<T, BASE>::clone() const
+std::unique_ptr<AbstractTyped> StoredValueArray<T, BASE>::clone() const
 {
-    return new StoredValueArray<T, AbstractTyped>(m_getter, m_setter, m_elementGetter, m_elementSetter);
+    return cppassist::make_unique<StoredValueArray<T, AbstractTyped>>(m_getter, m_setter, m_elementGetter, m_elementSetter);
 }
 
 template <typename T, typename BASE>
@@ -158,9 +158,9 @@ StoredValueArray<const T, BASE>::~StoredValueArray()
 }
 
 template <typename T, typename BASE>
-AbstractTyped * StoredValueArray<const T, BASE>::clone() const
+std::unique_ptr<AbstractTyped> StoredValueArray<const T, BASE>::clone() const
 {
-    return new StoredValueArray<const T, AbstractTyped>(
+    return cppassist::make_unique<StoredValueArray<const T, AbstractTyped>>(
       this->m_getter,
       this->m_setter,
       this->m_elementGetter,

--- a/source/cppexpose/include/cppexpose/typed/StoredValueSingle.hh
+++ b/source/cppexpose/include/cppexpose/typed/StoredValueSingle.hh
@@ -75,7 +75,7 @@ public:
     virtual ~StoredValueSingle();
 
     // Virtual AbstractTyped interface
-    virtual AbstractTyped * clone() const override;
+    virtual std::unique_ptr<AbstractTyped> clone() const override;
 
     // Virtual Typed<T> functions
     virtual T value() const override;
@@ -144,7 +144,7 @@ public:
     virtual ~StoredValueSingle();
 
     // Virtual AbstractTyped interface
-    virtual AbstractTyped * clone() const override;
+    virtual std::unique_ptr<AbstractTyped> clone() const override;
     virtual bool isReadOnly() const override;
 
     // Virtual Typed<T> functions

--- a/source/cppexpose/include/cppexpose/typed/StoredValueSingle.inl
+++ b/source/cppexpose/include/cppexpose/typed/StoredValueSingle.inl
@@ -44,9 +44,9 @@ StoredValueSingle<T, BASE>::~StoredValueSingle()
 }
 
 template <typename T, typename BASE>
-AbstractTyped * StoredValueSingle<T, BASE>::clone() const
+std::unique_ptr<AbstractTyped> StoredValueSingle<T, BASE>::clone() const
 {
-    return new StoredValueSingle<T, AbstractTyped>(m_getter, m_setter);
+    return cppassist::make_unique<StoredValueSingle<T, AbstractTyped>>(m_getter, m_setter);
 }
 
 template <typename T, typename BASE>
@@ -114,9 +114,9 @@ StoredValueSingle<const T, BASE>::~StoredValueSingle()
 }
 
 template <typename T, typename BASE>
-AbstractTyped * StoredValueSingle<const T, BASE>::clone() const
+std::unique_ptr<AbstractTyped> StoredValueSingle<const T, BASE>::clone() const
 {
-    return new StoredValueSingle<const T, AbstractTyped>(this->m_getter);
+    return cppassist::make_unique<StoredValueSingle<const T, AbstractTyped>>(this->m_getter);
 }
 
 template <typename T, typename BASE>

--- a/source/cppexpose/include/cppexpose/typed/TypedArray.hh
+++ b/source/cppexpose/include/cppexpose/typed/TypedArray.hh
@@ -32,12 +32,18 @@ public:
     /**
     *  @brief
     *    Copy constructor
+    *
+    *  @param[in] rhs
+    *    TypedArray to copy from
     */
     TypedArray(const TypedArray & rhs);
 
     /**
     *  @brief
     *    Move constructor
+    *
+    *  @param[in] rhs
+    *    TypedArray to move from
     */
     TypedArray(TypedArray && rhs);
 
@@ -50,12 +56,18 @@ public:
     /**
     *  @brief
     *    Copy assignment operator
+    *
+    *  @param[in] rhs
+    *    TypedArray to copy from
     */
     TypedArray & operator=(const TypedArray & rhs);
 
     /**
     *  @brief
     *    Move assignment operator
+    *
+    *  @param[in] rhs
+    *    TypedArray to move from
     */
     TypedArray & operator=(TypedArray && rhs);
 

--- a/source/cppexpose/include/cppexpose/typed/TypedArray.hh
+++ b/source/cppexpose/include/cppexpose/typed/TypedArray.hh
@@ -31,9 +31,33 @@ public:
 
     /**
     *  @brief
+    *    Copy constructor
+    */
+    TypedArray(const TypedArray & rhs);
+
+    /**
+    *  @brief
+    *    Move constructor
+    */
+    TypedArray(TypedArray && rhs);
+
+    /**
+    *  @brief
     *    Destructor
     */
     virtual ~TypedArray();
+
+    /**
+    *  @brief
+    *    Copy assignment operator
+    */
+    TypedArray & operator=(const TypedArray & rhs);
+
+    /**
+    *  @brief
+    *    Move assignment operator
+    */
+    TypedArray & operator=(TypedArray && rhs);
 
     /**
     *  @brief
@@ -78,7 +102,7 @@ public:
 
 
 protected:
-    std::vector<AbstractTyped *> m_subValues; ///< Typed accessors for sub-values (lazy initialized)
+    std::vector<std::unique_ptr<AbstractTyped>> m_subValues; ///< Typed accessors for sub-values (lazy initialized)
 };
 
 

--- a/source/cppexpose/include/cppexpose/typed/TypedArray.inl
+++ b/source/cppexpose/include/cppexpose/typed/TypedArray.inl
@@ -27,7 +27,7 @@ TypedArray<T, ET, Size, BASE>::TypedArray()
 
 template <typename T, typename ET, size_t Size, typename BASE>
 TypedArray<T, ET, Size, BASE>::TypedArray(const TypedArray & rhs)
-: Typed(rhs)
+: Typed<T, BASE>(rhs)
 {
     // don't copy m_subValues which will be lazy-initialized when used
 }
@@ -35,7 +35,7 @@ TypedArray<T, ET, Size, BASE>::TypedArray(const TypedArray & rhs)
 
 template <typename T, typename ET, size_t Size, typename BASE>
 TypedArray<T, ET, Size, BASE>::TypedArray(TypedArray && rhs)
-: Typed(std::move(rhs))
+: Typed<T, BASE>(std::move(rhs))
 , m_subValues(std::move(rhs.m_subValues))
 {
 }

--- a/source/cppexpose/include/cppexpose/typed/TypedArray.inl
+++ b/source/cppexpose/include/cppexpose/typed/TypedArray.inl
@@ -49,7 +49,7 @@ TypedArray<T, ET, Size, BASE>::~TypedArray()
 template <typename T, typename ET, size_t Size, typename BASE>
 TypedArray<T, ET, Size, BASE> & TypedArray<T, ET, Size, BASE>::operator=(const TypedArray & rhs)
 {
-    Typed<T, BASE>::operator=(std::move(rhs));
+    Typed<T, BASE>::operator=(rhs);
 
     // don't copy m_subValues which will be lazy-initialized when used
 

--- a/source/cppexpose/include/cppexpose/variant/Variant.hh
+++ b/source/cppexpose/include/cppexpose/variant/Variant.hh
@@ -324,7 +324,7 @@ public:
 
 
 protected:
-    AbstractTyped * m_value;
+    std::unique_ptr<AbstractTyped> m_value;
 };
 
 

--- a/source/cppexpose/include/cppexpose/variant/Variant.inl
+++ b/source/cppexpose/include/cppexpose/variant/Variant.inl
@@ -45,7 +45,7 @@ template <typename T>
 Variant Variant::fromValue(const T & value)
 {
     Variant variant;
-    variant.m_value = new DirectValue<T>(value);
+    variant.m_value = cppassist::make_unique<DirectValue<T>>(value);
     return variant;
 }
 
@@ -80,7 +80,7 @@ T Variant::value(const T & defaultValue) const
     // Type of variant is the wanted type
     if (m_value && typeid(T) == m_value->type())
     {
-        return reinterpret_cast<DirectValue<T> *>(m_value)->value();
+        return reinterpret_cast<DirectValue<T> *>(m_value.get())->value();
     }
 
     // Variant map or array to string conversion
@@ -103,7 +103,7 @@ template <typename T>
 T * Variant::ptr()
 {
     if (m_value && typeid(T) == m_value->type()) {
-        return static_cast<DirectValue<T> *>(m_value)->ptr();
+        return static_cast<DirectValue<T> *>(m_value.get())->ptr();
     } else {
         return nullptr;
     }
@@ -113,7 +113,7 @@ template <typename T>
 const T * Variant::ptr() const
 {
     if (m_value && typeid(T) == m_value->type()) {
-        return static_cast<const DirectValue<T> *>(m_value)->ptr();
+        return static_cast<const DirectValue<T> *>(m_value.get())->ptr();
     } else {
         return nullptr;
     }

--- a/source/cppexpose/include/cppexpose/variant/Variant.inl
+++ b/source/cppexpose/include/cppexpose/variant/Variant.inl
@@ -80,7 +80,7 @@ T Variant::value(const T & defaultValue) const
     // Type of variant is the wanted type
     if (m_value && typeid(T) == m_value->type())
     {
-        return reinterpret_cast<DirectValue<T> *>(m_value.get())->value();
+        return static_cast<DirectValue<T> *>(m_value.get())->value();
     }
 
     // Variant map or array to string conversion

--- a/source/cppexpose/source/function/Function.cpp
+++ b/source/cppexpose/source/function/Function.cpp
@@ -9,8 +9,8 @@ namespace cppexpose
 {
 
 
-Function::Function(AbstractFunction * func)
-: m_func(func)
+Function::Function(std::unique_ptr<AbstractFunction> && func)
+: m_func(std::move(func))
 {
 }
 
@@ -21,16 +21,10 @@ Function::Function(const Function & other)
 
 Function::~Function()
 {
-    delete m_func;
 }
 
 Function & Function::operator=(const Function & other)
 {
-    // Delete old function
-    if (m_func) {
-        delete m_func;
-    }
-
     // Copy function
     m_func = other.m_func ? other.m_func->clone() : nullptr;
     return *this;

--- a/source/cppexpose/source/plugin/ComponentManager.cpp
+++ b/source/cppexpose/source/plugin/ComponentManager.cpp
@@ -190,7 +190,7 @@ bool ComponentManager::loadLibrary(const std::string & filePath, bool reload)
 {
     // Check if library is already loaded and reload is not requested
     const auto it = m_librariesByFilePath.find(filePath);
-    const auto alreadyLoaded = it != m_librariesByFilePath.end();
+    const auto alreadyLoaded = (it != m_librariesByFilePath.end());
     if (alreadyLoaded && !reload) {
         return true;
     }
@@ -248,8 +248,12 @@ bool ComponentManager::loadLibrary(const std::string & filePath, bool reload)
 
 void ComponentManager::unloadLibrary(PluginLibrary * library)
 {
+    // Check if library is loaded
     auto it = std::find_if(m_librariesByFilePath.begin(), m_librariesByFilePath.end(),
-        [library](const std::pair<const std::string, std::unique_ptr<PluginLibrary>> & item) { return item.second.get() == library; });
+        [library](const std::pair<const std::string, std::unique_ptr<PluginLibrary>> & item)
+        {
+            return item.second.get() == library;
+        });
     if (it == m_librariesByFilePath.end())
     {
         return;

--- a/source/cppexpose/source/plugin/ComponentManager.cpp
+++ b/source/cppexpose/source/plugin/ComponentManager.cpp
@@ -38,8 +38,8 @@ ComponentManager::~ComponentManager()
     // inside the plugin library, when deinitialize() is called.
 
     // Unload plugin libraries
-    for (const std::pair<std::string, PluginLibrary *> & it : m_librariesByFilePath) {
-        unloadLibrary(it.second);
+    for (const auto & it : m_librariesByFilePath) {
+        unloadLibrary(it.second.get());
     }
 }
 
@@ -135,8 +135,8 @@ std::vector<PluginLibrary *> ComponentManager::pluginLibraries() const
     std::vector<PluginLibrary *> pluginLibraries;
     pluginLibraries.reserve(m_librariesByFilePath.size());
 
-    for (auto libraryIterator : m_librariesByFilePath)
-        pluginLibraries.push_back(libraryIterator.second);
+    for (const auto & libraryIterator : m_librariesByFilePath)
+        pluginLibraries.push_back(libraryIterator.second.get());
 
     return pluginLibraries;
 }
@@ -189,8 +189,9 @@ void ComponentManager::printComponents() const
 bool ComponentManager::loadLibrary(const std::string & filePath, bool reload)
 {
     // Check if library is already loaded and reload is not requested
-    auto it = m_librariesByFilePath.find(filePath);
-    if (it != m_librariesByFilePath.end() && !reload) {
+    const auto it = m_librariesByFilePath.find(filePath);
+    const auto alreadyLoaded = it != m_librariesByFilePath.end();
+    if (alreadyLoaded && !reload) {
         return true;
     }
 
@@ -198,30 +199,20 @@ bool ComponentManager::loadLibrary(const std::string & filePath, bool reload)
     cpplocate::ModuleInfo modInfo;
     modInfo.load(filePath + ".modinfo");
 
-    // If library was already loaded, remember it in case reloading fails
-    PluginLibrary * previous = nullptr;
-    if (it != m_librariesByFilePath.end()) {
-        previous = it->second;
-    }
-
     // Open plugin library
-    PluginLibrary * library = new PluginLibrary(filePath);
+    auto library = cppassist::make_unique<PluginLibrary>(filePath);
     if (!library->isValid())
     {
         // Loading failed. Destroy library object and return failure.
-        cppassist::warning() << (previous ? "Reloading" : "Loading") << " plugin(s) from '" << filePath << "' failed.";
+        cppassist::warning() << (alreadyLoaded ? "Reloading" : "Loading") << " plugin(s) from '" << filePath << "' failed.";
 
-        delete library;
         return false;
     }
 
-    // Library has been loaded. Unload previous incarnation.
-    if (previous) {
-        unloadLibrary(previous);
+    // If library was already loaded, unload previous incarnation.
+    if (alreadyLoaded) {
+        unloadLibrary(it->second.get());
     }
-
-    // Add library to list (in case of reload, this overwrites the previous)
-    m_librariesByFilePath[filePath] = library;
 
     // Initialize plugin library
     library->initialize();
@@ -248,20 +239,25 @@ bool ComponentManager::loadLibrary(const std::string & filePath, bool reload)
         m_componentsByName[component->name()] = component;
     }
 
+    // Add library to list (in case of reload, this overwrites the previous)
+    m_librariesByFilePath[filePath] = std::move(library);
+
     // Return success
     return true;
 }
 
 void ComponentManager::unloadLibrary(PluginLibrary * library)
 {
-    // Check parameters
-    if (!library) {
+    auto it = std::find_if(m_librariesByFilePath.begin(), m_librariesByFilePath.end(),
+        [library](const std::pair<const std::string, std::unique_ptr<PluginLibrary>> & item) { return item.second.get() == library; });
+    if (it == m_librariesByFilePath.end())
+    {
         return;
     }
 
     // Unload plugin library
     library->deinitialize();
-    delete library;
+    m_librariesByFilePath.erase(it);
 }
 
 

--- a/source/cppexpose/source/reflection/AbstractProperty.cpp
+++ b/source/cppexpose/source/reflection/AbstractProperty.cpp
@@ -107,7 +107,7 @@ bool AbstractProperty::removeOption(const std::string & key)
     return true;
 }
 
-void AbstractProperty::initProperty(const std::string & name, Object * parent, PropertyOwnership ownership)
+void AbstractProperty::initProperty(const std::string & name, Object * parent)
 {
     // Store name
     m_name = name;
@@ -118,7 +118,7 @@ void AbstractProperty::initProperty(const std::string & name, Object * parent, P
     // Add property to parent object
     if (parent)
     {
-        parent->addProperty(this, ownership);
+        parent->addProperty(this);
     }
 }
 

--- a/source/cppexpose/source/reflection/Method.cpp
+++ b/source/cppexpose/source/reflection/Method.cpp
@@ -8,15 +8,15 @@ namespace cppexpose
 {
 
 
-Method::Method(AbstractFunction * func, Object * parent)
-: Function(func)
+Method::Method(std::unique_ptr<AbstractFunction> && func, Object * parent)
+: Function(std::move(func))
 , m_name("")
 , m_parent(parent)
 {
 }
 
-Method::Method(const std::string & name, AbstractFunction * func, Object * parent)
-: Function(func)
+Method::Method(const std::string & name, std::unique_ptr<AbstractFunction> && func, Object * parent)
+: Function(std::move(func))
 , m_name(name)
 , m_parent(parent)
 {

--- a/source/cppexpose/source/reflection/Object.cpp
+++ b/source/cppexpose/source/reflection/Object.cpp
@@ -191,10 +191,10 @@ bool Object::isObject() const
     return true;
 }
 
-AbstractTyped * Object::clone() const
+std::unique_ptr<AbstractTyped> Object::clone() const
 {
     // [TODO]
-    return new Object(name());
+    return cppassist::make_unique<Object>(name());
 }
 
 const std::type_info & Object::type() const

--- a/source/cppexpose/source/scripting/DuktapeObjectWrapper.h
+++ b/source/cppexpose/source/scripting/DuktapeObjectWrapper.h
@@ -112,11 +112,11 @@ protected:
 
 
 protected:
-    duk_context                         * m_context;       ///< Duktape context
-    DuktapeScriptBackend                * m_scriptBackend; ///< Duktape scripting backend
-    Object                              * m_obj;           ///< The wrapped object
-    int                                   m_stashIndex;    ///< Index of the wrapped object in the stash
-    std::vector<DuktapeObjectWrapper *>   m_subObjects;    ///< List of wrapped sub-objects
+    duk_context                                      * m_context;       ///< Duktape context
+    DuktapeScriptBackend                             * m_scriptBackend; ///< Duktape scripting backend
+    Object                                           * m_obj;           ///< The wrapped object
+    int                                                m_stashIndex;    ///< Index of the wrapped object in the stash
+    std::vector<std::unique_ptr<DuktapeObjectWrapper>> m_subObjects;    ///< List of wrapped sub-objects
 
     // Connections to the wrapped object
     cppexpose::ScopedConnection m_beforeDestroyConnection;

--- a/source/cppexpose/source/scripting/DuktapeScriptBackend.cpp
+++ b/source/cppexpose/source/scripting/DuktapeScriptBackend.cpp
@@ -37,12 +37,6 @@ DuktapeScriptBackend::DuktapeScriptBackend()
 
 DuktapeScriptBackend::~DuktapeScriptBackend()
 {
-    // Delete global object wrapper
-    if (m_globalObjWrapper)
-    {
-        delete m_globalObjWrapper;
-    }
-
     // Destroy duktape script context
     duk_destroy_heap(m_context);
 }
@@ -77,13 +71,10 @@ void DuktapeScriptBackend::setGlobalObject(Object * obj)
         duk_push_global_object(m_context);
         duk_del_prop_string(m_context, duk_get_top_index(m_context), obj->name().c_str());
         duk_pop(m_context);
-
-        // Destroy wrapper
-        delete m_globalObjWrapper;
     }
 
     // Create object wrapper
-    m_globalObjWrapper = new DuktapeObjectWrapper(this);
+    m_globalObjWrapper = cppassist::make_unique<DuktapeObjectWrapper>(this);
 
     // Wrap object in javascript object and put it into the global object
     duk_push_global_object(m_context);

--- a/source/cppexpose/source/scripting/DuktapeScriptBackend.cpp
+++ b/source/cppexpose/source/scripting/DuktapeScriptBackend.cpp
@@ -158,7 +158,7 @@ Variant DuktapeScriptBackend::fromDukStack(duk_idx_t index)
         duk_pop(m_context);
 
         // Return callable function
-        Function function(new DuktapeScriptFunction(this, funcIndex));
+        Function function(cppassist::make_unique<DuktapeScriptFunction>(this, funcIndex));
         return Variant::fromValue<Function>(function);
     }
 

--- a/source/cppexpose/source/scripting/DuktapeScriptBackend.h
+++ b/source/cppexpose/source/scripting/DuktapeScriptBackend.h
@@ -3,6 +3,7 @@
 
 
 #include <string>
+#include <memory>
 
 #include <cppexpose/scripting/AbstractScriptBackend.h>
 
@@ -95,8 +96,8 @@ protected:
 
 
 protected:
-    duk_context          * m_context;          ///< Duktape context (never null)
-    DuktapeObjectWrapper * m_globalObjWrapper; ///< Global object wrapper (can be null)
+    duk_context                         * m_context;          ///< Duktape context (never null)
+    std::unique_ptr<DuktapeObjectWrapper> m_globalObjWrapper; ///< Global object wrapper (can be null)
 };
 
 

--- a/source/cppexpose/source/scripting/DuktapeScriptFunction.cpp
+++ b/source/cppexpose/source/scripting/DuktapeScriptFunction.cpp
@@ -1,6 +1,8 @@
 
 #include "DuktapeScriptFunction.h"
 
+#include <cppassist/memory/make_unique.h>
+
 #include <cppexpose/variant/Variant.h>
 #include <cppexpose/scripting/ScriptContext.h>
 
@@ -18,9 +20,9 @@ DuktapeScriptFunction::DuktapeScriptFunction(DuktapeScriptBackend * scriptBacken
 {
 }
 
-AbstractFunction * DuktapeScriptFunction::clone()
+std::unique_ptr<AbstractFunction> DuktapeScriptFunction::clone()
 {
-    return new DuktapeScriptFunction(m_scriptBackend, m_stashIndex);
+    return cppassist::make_unique<DuktapeScriptFunction>(m_scriptBackend, m_stashIndex);
 }
 
 Variant DuktapeScriptFunction::call(const std::vector<Variant> & args)

--- a/source/cppexpose/source/scripting/DuktapeScriptFunction.h
+++ b/source/cppexpose/source/scripting/DuktapeScriptFunction.h
@@ -36,7 +36,7 @@ public:
     DuktapeScriptFunction(DuktapeScriptBackend * scriptBackend, int stashIndex);
 
     // Virtual AbstractFunction interface
-    virtual AbstractFunction * clone() override;
+    virtual std::unique_ptr<AbstractFunction> clone() override;
     virtual Variant call(const std::vector<Variant> & args) override;
 
 

--- a/source/cppexpose/source/scripting/ScriptContext.cpp
+++ b/source/cppexpose/source/scripting/ScriptContext.cpp
@@ -21,13 +21,13 @@ ScriptContext::ScriptContext(const std::string & backend)
     // Javascript (duktape)
     if (backend == "duktape" || backend == "javascript" || backend == "js")
     {
-        m_backend = new DuktapeScriptBackend();
+        m_backend = cppassist::make_unique<DuktapeScriptBackend>();
         m_backend->initialize(this);
     }
 }
 
-ScriptContext::ScriptContext(AbstractScriptBackend * backend)
-: m_backend(backend)
+ScriptContext::ScriptContext(std::unique_ptr<AbstractScriptBackend> && backend)
+: m_backend(std::move(backend))
 , m_globalObject(nullptr)
 {
     // Register backend
@@ -38,8 +38,6 @@ ScriptContext::ScriptContext(AbstractScriptBackend * backend)
 
 ScriptContext::~ScriptContext()
 {
-    // Release backend
-    delete m_backend;
 }
 
 Object * ScriptContext::globalObject() const

--- a/source/cppexpose/source/scripting/example/TreeNode.cpp
+++ b/source/cppexpose/source/scripting/example/TreeNode.cpp
@@ -2,6 +2,7 @@
 #include <cppexpose/scripting/example/TreeNode.h>
 
 #include <cppassist/string/conversion.h>
+#include <cppassist/memory/make_unique.h>
 
 #include <iostream>
 
@@ -49,10 +50,10 @@ void TreeNode::expand()
     }
 
     // Create child nodes
-    m_left = std::make_unique<TreeNode>("left");
+    m_left = cppassist::make_unique<TreeNode>("left");
     addProperty(m_left.get());
 
-    m_right = std::make_unique<TreeNode>("right");
+    m_right = cppassist::make_unique<TreeNode>("right");
     addProperty(m_right.get());
 }
 

--- a/source/cppexpose/source/scripting/example/TreeNode.cpp
+++ b/source/cppexpose/source/scripting/example/TreeNode.cpp
@@ -49,11 +49,11 @@ void TreeNode::expand()
     }
 
     // Create child nodes
-    m_left = new TreeNode("left");
-    addProperty(m_left, PropertyOwnership::Parent);
+    m_left = std::make_unique<TreeNode>("left");
+    addProperty(m_left.get());
 
-    m_right = new TreeNode("right");
-    addProperty(m_right, PropertyOwnership::Parent);
+    m_right = std::make_unique<TreeNode>("right");
+    addProperty(m_right.get());
 }
 
 void TreeNode::collapse()
@@ -61,13 +61,13 @@ void TreeNode::collapse()
     // Destroy child nodes
     if (m_left)
     {
-        destroyProperty(m_left);
+        removeProperty(m_left.get());
         m_left = nullptr;
     }
 
     if (m_right)
     {
-        destroyProperty(m_right);
+        removeProperty(m_right.get());
         m_right = nullptr;
     }
 }

--- a/source/cppexpose/source/signal/Connection.cpp
+++ b/source/cppexpose/source/signal/Connection.cpp
@@ -23,7 +23,7 @@ Connection::Connection(Connection && other)
 }
 
 Connection::Connection(const AbstractSignal * signal, Id id)
-: m_state(new State{signal, id})
+: m_state(std::make_shared<State>(signal, id))
 {
 }
 
@@ -63,5 +63,10 @@ void Connection::detach()
     }
 }
 
+Connection::State::State(const AbstractSignal * signal, Id id)
+: signal(signal)
+, id(id)
+{
+}
 
 } // namespace cppexpose

--- a/source/cppexpose/source/variant/Variant.cpp
+++ b/source/cppexpose/source/variant/Variant.cpp
@@ -12,21 +12,21 @@ namespace cppexpose
 Variant Variant::array()
 {
     Variant variant;
-    variant.m_value = new DirectValue<VariantArray>(VariantArray());
+    variant.m_value = cppassist::make_unique<DirectValue<VariantArray>>(VariantArray());
     return variant;
 }
 
 Variant Variant::array(size_t count)
 {
     Variant variant;
-    variant.m_value = new DirectValue<VariantArray>(VariantArray(count));
+    variant.m_value = cppassist::make_unique<DirectValue<VariantArray>>(VariantArray(count));
     return variant;
 }
 
 Variant Variant::map()
 {
     Variant variant;
-    variant.m_value = new DirectValue<VariantMap>(VariantMap());
+    variant.m_value = cppassist::make_unique<DirectValue<VariantMap>>(VariantMap());
     return variant;
 }
 
@@ -41,109 +41,101 @@ Variant::Variant(const Variant & variant)
 }
 
 Variant::Variant(bool value)
-: m_value(new DirectValue<bool>(value))
+: m_value(cppassist::make_unique<DirectValue<bool>>(value))
 {
 }
 
 Variant::Variant(char value)
-: m_value(new DirectValue<char>(value))
+: m_value(cppassist::make_unique<DirectValue<char>>(value))
 {
 }
 
 Variant::Variant(unsigned char value)
-: m_value(new DirectValue<unsigned char>(value))
+: m_value(cppassist::make_unique<DirectValue<unsigned char>>(value))
 {
 }
 
 Variant::Variant(short value)
-: m_value(new DirectValue<short>(value))
+: m_value(cppassist::make_unique<DirectValue<short>>(value))
 {
 }
 
 Variant::Variant(unsigned short value)
-: m_value(new DirectValue<unsigned short>(value))
+: m_value(cppassist::make_unique<DirectValue<unsigned short>>(value))
 {
 }
 
 Variant::Variant(int value)
-: m_value(new DirectValue<int>(value))
+: m_value(cppassist::make_unique<DirectValue<int>>(value))
 {
 }
 
 Variant::Variant(unsigned int value)
-: m_value(new DirectValue<unsigned int>(value))
+: m_value(cppassist::make_unique<DirectValue<unsigned int>>(value))
 {
 }
 
 Variant::Variant(long value)
-: m_value(new DirectValue<long>(value))
+: m_value(cppassist::make_unique<DirectValue<long>>(value))
 {
 }
 
 Variant::Variant(unsigned long value)
-: m_value(new DirectValue<unsigned long>(value))
+: m_value(cppassist::make_unique<DirectValue<unsigned long>>(value))
 {
 }
 
 Variant::Variant(long long value)
-: m_value(new DirectValue<long long>(value))
+: m_value(cppassist::make_unique<DirectValue<long long>>(value))
 {
 }
 
 Variant::Variant(unsigned long long value)
-: m_value(new DirectValue<unsigned long long>(value))
+: m_value(cppassist::make_unique<DirectValue<unsigned long long>>(value))
 {
 }
 
 Variant::Variant(float value)
-: m_value(new DirectValue<float>(value))
+: m_value(cppassist::make_unique<DirectValue<float>>(value))
 {
 }
 
 Variant::Variant(double value)
-: m_value(new DirectValue<double>(value))
+: m_value(cppassist::make_unique<DirectValue<double>>(value))
 {
 }
 
 Variant::Variant(const char * value)
-: m_value(new DirectValue<std::string>(std::string(value)))
+: m_value(cppassist::make_unique<DirectValue<std::string>>(std::string(value)))
 {
 }
 
 Variant::Variant(const std::string & value)
-: m_value(new DirectValue<std::string>(value))
+: m_value(cppassist::make_unique<DirectValue<std::string>>(value))
 {
 }
 
 Variant::Variant(const std::vector<std::string> & value)
-: m_value(new DirectValue< std::vector<std::string> >(value))
+: m_value(cppassist::make_unique<DirectValue< std::vector<std::string> >>(value))
 {
 }
 
 Variant::Variant(const VariantArray & array)
-: m_value(new DirectValue<VariantArray>(array))
+: m_value(cppassist::make_unique<DirectValue<VariantArray>>(array))
 {
 }
 
 Variant::Variant(const VariantMap & map)
-: m_value(new DirectValue<VariantMap>(map))
+: m_value(cppassist::make_unique<DirectValue<VariantMap>>(map))
 {
 }
 
 Variant::~Variant()
 {
-    if (m_value)
-    {
-        delete m_value;
-    }
 }
 
 Variant & Variant::operator=(const Variant & variant)
 {
-    if (m_value) {
-        delete m_value;
-    }
-
     m_value = variant.m_value ? variant.m_value->clone() : nullptr;
 
     return *this;

--- a/source/examples/plugin/BinaryOperatorComponent.h
+++ b/source/examples/plugin/BinaryOperatorComponent.h
@@ -2,6 +2,8 @@
 #pragma once
 
 
+#include <memory>
+
 #include <cppexpose/plugin/AbstractComponent.h>
 
 
@@ -23,8 +25,8 @@ public:
     {
     }
 
-    virtual BinaryOperator * createInstance(int a, int b) = 0;
-    virtual BinaryOperator * createInstance(int a) = 0;
+    virtual std::unique_ptr<BinaryOperator> createInstance(int a, int b) = 0;
+    virtual std::unique_ptr<BinaryOperator> createInstance(int a) = 0;
 };
 
 /**
@@ -43,13 +45,13 @@ public:
     {
     }
 
-    virtual BinaryOperator * createInstance(int a, int b) override
+    virtual std::unique_ptr<BinaryOperator> createInstance(int a, int b) override
     {
-        return new CLASS(a, b);
+        return cppassist::make_unique<CLASS>(a, b);
     }
 
-    virtual BinaryOperator * createInstance(int a)
+    virtual std::unique_ptr<BinaryOperator> createInstance(int a) override
     {
-        return new CLASS(a, a);
+        return cppassist::make_unique<CLASS>(a, a);
     }
 };

--- a/source/examples/plugin/CMakeLists.txt
+++ b/source/examples/plugin/CMakeLists.txt
@@ -32,6 +32,7 @@ set(sources
     Addition.h
     Multiplication.cpp
     Multiplication.h
+    BinaryOperatorComponent.h
 )
 
 

--- a/source/examples/plugin/main.cpp
+++ b/source/examples/plugin/main.cpp
@@ -56,7 +56,7 @@ int main(int, char * [])
             continue;
 
         // Instanciate example
-        cppexpose::Example * example = component->createInstance();
+        auto example = component->createInstance();
 
         // Evaluate operator
         std::cout << name << std::endl;
@@ -77,7 +77,7 @@ int main(int, char * [])
             continue;
 
         // Instanciate operator
-        BinaryOperator * op = component->createInstance(2, 3);
+        auto op = component->createInstance(2, 3);
 
         // Evaluate operator
         std::cout << name << std::endl;

--- a/source/examples/property/main.cpp
+++ b/source/examples/property/main.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include <cppassist/string/conversion.h>
+#include <cppassist/memory/make_unique.h>
 
 #include <cppexpose/reflection/DynamicProperty.h>
 
@@ -76,7 +77,7 @@ int main(int, char * [])
     for (int i=1; i<=4; i++)
     {
         std::string name = "sub" + cppassist::string::toString<int>(i);
-        auto sub = std::make_unique<Object>(name);
+        auto sub = cppassist::make_unique<Object>(name);
 
         for (int j=1; j<=4; j++)
         {

--- a/source/examples/property/main.cpp
+++ b/source/examples/property/main.cpp
@@ -72,7 +72,7 @@ int main(int, char * [])
     std::cout << std::endl;
 
     // Create object with sub-objects and dynamic properties
-    Object * root = new Object;
+    auto root = cppassist::make_unique<Object>();
 
     for (int i=1; i<=4; i++)
     {
@@ -94,8 +94,6 @@ int main(int, char * [])
     values = root->toVariant();
     std::cout << values.toJSON(JSON::Beautify) << std::endl;
     std::cout << std::endl;
-
-    delete root;
 
     // Exit
     return 0;

--- a/source/examples/property/main.cpp
+++ b/source/examples/property/main.cpp
@@ -76,8 +76,7 @@ int main(int, char * [])
     for (int i=1; i<=4; i++)
     {
         std::string name = "sub" + cppassist::string::toString<int>(i);
-        Object * sub = new Object(name);
-        root->addProperty(sub, PropertyOwnership::Parent);
+        auto sub = std::make_unique<Object>(name);
 
         for (int j=1; j<=4; j++)
         {
@@ -85,8 +84,10 @@ int main(int, char * [])
             sub->createDynamicProperty<int>(name, i * 10 + j);
         }
 
-        sub->destroyProperty(sub->property("value2"));
-        sub->destroyProperty(sub->property("value3"));
+        sub->removeProperty(sub->property("value2"));
+        sub->removeProperty(sub->property("value3"));
+
+        root->addProperty(std::move(sub));
     }
 
     values = root->toVariant();

--- a/source/tests/cppexpose-test/CMakeLists.txt
+++ b/source/tests/cppexpose-test/CMakeLists.txt
@@ -92,9 +92,19 @@ target_compile_definitions(${target}
 # Compile options
 # 
 
+# MSVC compiler options
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+    set(TARGET_COMPILE_OPTIONS ${DEFAULT_COMPILE_OPTIONS}
+    PRIVATE
+        /bigobj
+
+    PUBLIC
+    )
+endif ()
+
 target_compile_options(${target}
     PRIVATE
-    ${DEFAULT_COMPILE_OPTIONS}
+    ${TARGET_COMPILE_OPTIONS}
 )
 
 

--- a/source/tests/cppexpose-test/DirectValueInstantiationTest.cpp
+++ b/source/tests/cppexpose-test/DirectValueInstantiationTest.cpp
@@ -31,11 +31,8 @@ TYPED_TEST_CASE(DirectValueInstantiation_test, InstantiationTypes);
 
 TYPED_TEST(DirectValueInstantiation_test, instantiateDirectValue)
 {
-
-    auto directVal = new DirectValue<TypeParam>(TypeParam{});
+    auto directVal = cppassist::make_unique<DirectValue<TypeParam>>(TypeParam{});
 
     ASSERT_EQ(typeid(typename std::remove_cv<TypeParam>::type), directVal->type());
-
-    delete directVal;
 }
 

--- a/source/tests/cppexpose-test/PropertyInstantiationTest.cpp
+++ b/source/tests/cppexpose-test/PropertyInstantiationTest.cpp
@@ -61,11 +61,9 @@ TYPED_TEST(PropertyInstantiation_test, instantiatePropertyWith_String_LambdaGett
     {
     };
 
-    auto prop = new Property<TypeParam>("Property", &object, get, set);
+    auto prop = cppassist::make_unique<Property<TypeParam>>("Property", &object, get, set);
 
     ASSERT_EQ(typeid(TypeParam), prop->type());
-
-    delete prop;
 }
 
 
@@ -73,24 +71,19 @@ TYPED_TEST(PropertyInstantiation_test, instantiatePropertyWith_String_StaticGett
 {
     Object object;
 
-    auto prop = new Property<TypeParam>("Property", &object, &staticGetter<TypeParam>, &staticSetter<TypeParam>);
+    auto prop = cppassist::make_unique<Property<TypeParam>>("Property", &object, &staticGetter<TypeParam>, &staticSetter<TypeParam>);
 
     ASSERT_EQ(typeid(TypeParam), prop->type());
-
-    delete prop;
 }
 
 TYPED_TEST(PropertyInstantiation_test, instantiatePropertyWith_String_Object_GetterConst_SetterConst)
 {
     Object object;
 
-    auto obj = new MyObject<TypeParam>("TestObject");
-    auto prop = new Property<TypeParam>("Property", &object, obj, &MyObject<TypeParam>::getterconst, &MyObject<TypeParam>::setterconst);
+    auto obj = cppassist::make_unique<MyObject<TypeParam>>("TestObject");
+    auto prop = cppassist::make_unique<Property<TypeParam>>("Property", &object, obj.get(), &MyObject<TypeParam>::getterconst, &MyObject<TypeParam>::setterconst);
 
     ASSERT_EQ(typeid(TypeParam), prop->type());
-
-    delete prop;
-    delete obj;
 }
 
 // Property instantiaton (read only)
@@ -104,11 +97,9 @@ TYPED_TEST(PropertyInstantiation_test, instantiateConstPropertyWith_String_Lambd
         return TypeParam();
     };
 
-    auto prop = new Property<const TypeParam>("Property", &object, get);
+    auto prop = cppassist::make_unique<Property<const TypeParam>>("Property", &object, get);
 
     ASSERT_EQ(typeid(TypeParam), prop->type());
-
-    delete prop;
 }
 
 
@@ -116,9 +107,7 @@ TYPED_TEST(PropertyInstantiation_test, instantiateConstPropertyWith_String_Stati
 {
     Object object;
 
-    auto prop = new Property<const TypeParam>("Property", &object, &staticGetter<TypeParam>);
+    auto prop = cppassist::make_unique<Property<const TypeParam>>("Property", &object, &staticGetter<TypeParam>);
 
     ASSERT_EQ(typeid(TypeParam), prop->type());
-
-    delete prop;
 }

--- a/source/tests/cppexpose-test/PropertyTest.cpp
+++ b/source/tests/cppexpose-test/PropertyTest.cpp
@@ -88,7 +88,7 @@ TEST_F(PropertyTest, boolSet)
         value = val;
     };
 
-    auto prop = new Property<bool>("Property", &object, get, set);
+    auto prop = cppassist::make_unique<Property<bool>>("Property", &object, get, set);
     
     prop->valueChanged.connect(callback);
     
@@ -96,8 +96,6 @@ TEST_F(PropertyTest, boolSet)
     
     ASSERT_FALSE(prop->toBool());
     ASSERT_TRUE(callbackVar);
-
-    delete prop;
 }
 
 TEST_F(PropertyTest, ArraySet)
@@ -112,12 +110,10 @@ TEST_F(PropertyTest, ArraySet)
     auto elementGetter = [&value](const int & index) -> int {return value[index];};
     auto elementSetter = [&value](const int & index, const int & val){value[index] = val;};
 
-    auto prop = new Property<std::array<int, 4>>("Property", &object, getter, setter, elementGetter, elementSetter);
+    auto prop = cppassist::make_unique<Property<std::array<int, 4>>>("Property", &object, getter, setter, elementGetter, elementSetter);
 
     prop->setElement(0, 10);
     ASSERT_EQ(10, prop->getElement(0));
-
-    delete prop;
 }
 
 TEST_F(PropertyTest, stringSet)
@@ -142,7 +138,7 @@ TEST_F(PropertyTest, stringSet)
         value = val;
     };
 
-    auto prop = new Property<std::string>("Property", &object, get, set);
+    auto prop = cppassist::make_unique<Property<std::string>>("Property", &object, get, set);
     
     prop->valueChanged.connect(callback);
     
@@ -150,8 +146,6 @@ TEST_F(PropertyTest, stringSet)
     
     ASSERT_EQ("bar", prop->toString());
     ASSERT_TRUE(callbackVar);
-
-    delete prop;
 }
 
 TEST_F(PropertyTest, conversionTest_int)
@@ -160,14 +154,12 @@ TEST_F(PropertyTest, conversionTest_int)
     
     int intVar = 0;
     
-    auto intProp = new Property<int>("intProperty", &object, [&](){return intVar;}, [](const int&){});
+    auto intProp = cppassist::make_unique<Property<int>>("intProperty", &object, [&](){return intVar;}, [](const int&){});
     
     ASSERT_DOUBLE_EQ(intVar, intProp->toDouble());
     ASSERT_EQ(intVar, intProp->toLongLong());
     ASSERT_EQ(intVar, intProp->toULongLong());
     ASSERT_EQ("0", intProp->toString());
-
-    delete intProp;
 }
 
 TEST_F(PropertyTest, conversionTest_negative_int)
@@ -176,14 +168,12 @@ TEST_F(PropertyTest, conversionTest_negative_int)
     
     int intVar = -3;
     
-    auto intProp = new Property<int>("intProperty", &object, [&](){return intVar;}, [](const int&){});
+    auto intProp = cppassist::make_unique<Property<int>>("intProperty", &object, [&](){return intVar;}, [](const int&){});
     
     ASSERT_DOUBLE_EQ(intVar, intProp->toDouble());
     ASSERT_EQ(intVar, intProp->toLongLong());
     ASSERT_EQ(intVar, intProp->toULongLong());
     ASSERT_EQ("-3", intProp->toString());
-
-    delete intProp;
 }
 
 TEST_F(PropertyTest, conversionTest_string)
@@ -192,14 +182,12 @@ TEST_F(PropertyTest, conversionTest_string)
 
     std::string strVar = "3";
 
-    auto intProp = new Property<std::string>("stringProperty", &object, [&](){return strVar;}, [](const std::string&){});
+    auto intProp = cppassist::make_unique<Property<std::string>>("stringProperty", &object, [&](){return strVar;}, [](const std::string&){});
 
     ASSERT_DOUBLE_EQ(3, intProp->toDouble());
     ASSERT_EQ(3, intProp->toLongLong());
     ASSERT_EQ(3, intProp->toULongLong());
     ASSERT_EQ("3", intProp->toString());
-
-    delete intProp;
 }
 
 TEST_F(PropertyTest, conversionTest_string_variant)
@@ -208,11 +196,9 @@ TEST_F(PropertyTest, conversionTest_string_variant)
 
     std::string strVar = "test";
 
-    auto strProp = new Property<std::string>("stringProperty", &object, [&](){return strVar;}, [](const std::string&){});
+    auto strProp = cppassist::make_unique<Property<std::string>>("stringProperty", &object, [&](){return strVar;}, [](const std::string&){});
 
     ASSERT_EQ("test", strProp->toVariant().toString());
-
-    delete strProp;
 }
 
 TEST_F(PropertyTest, typesBool)

--- a/source/tests/cppexpose-test/StoredValueInstantiationTest.cpp
+++ b/source/tests/cppexpose-test/StoredValueInstantiationTest.cpp
@@ -33,10 +33,8 @@ TYPED_TEST_CASE(StoredValueInstantiation_test, InstantiationTypes);
 
 TYPED_TEST(StoredValueInstantiation_test, instantiateStoredValue)
 {
-    auto storedVal = new StoredValue<TypeParam>();
+    auto storedVal = cppassist::make_unique<StoredValue<TypeParam>>();
 
     ASSERT_EQ(typeid(typename std::remove_cv<TypeParam>::type), storedVal->type());
-
-    delete storedVal;
 }
 


### PR DESCRIPTION
Functions that take a `PropertyOwnership` flag are replaced with two overloads for `std::unique_ptr &&` (transfer ownership) and a raw pointer (non-owning).

Tested with Visual Studio 2015 and Apple Clang 8.