### PR TITLE
Implement automatic registration of components

### DIFF
--- a/source/cppexpose/CMakeLists.txt
+++ b/source/cppexpose/CMakeLists.txt
@@ -153,6 +153,7 @@ set(headers
 
     ${include_path}/plugin/ComponentManager.h
     ${include_path}/plugin/ComponentManager.inl
+    ${include_path}/plugin/ComponentRegistry.h
     ${include_path}/plugin/AbstractComponent.h
     ${include_path}/plugin/AbstractGenericComponent.h
     ${include_path}/plugin/AbstractGenericComponent.inl
@@ -201,6 +202,7 @@ set(sources
     ${source_path}/scripting/DuktapeObjectWrapper.h
 
     ${source_path}/plugin/ComponentManager.cpp
+    ${source_path}/plugin/ComponentRegistry.cpp
     ${source_path}/plugin/AbstractComponent.cpp
     ${source_path}/plugin/PluginLibrary.cpp
     ${source_path}/plugin/Example.cpp

--- a/source/cppexpose/include/cppexpose/plugin/ComponentManager.h
+++ b/source/cppexpose/include/cppexpose/plugin/ComponentManager.h
@@ -206,15 +206,6 @@ public:
 
     /**
     *  @brief
-    *    Add component
-    *
-    *  @param[in] component
-    *    Component
-    */
-    void addComponent(AbstractComponent * component);
-
-    /**
-    *  @brief
     *    Print list of available components to log
     */
     void printComponents() const;
@@ -248,6 +239,15 @@ protected:
     *    plugins must be remaining.
     */
     void unloadLibrary(PluginLibrary * library);
+
+    /**
+    *  @brief
+    *    Add component
+    *
+    *  @param[in] component
+    *    Component
+    */
+    void addComponent(AbstractComponent * component);
 
     /**
     *  @brief

--- a/source/cppexpose/include/cppexpose/plugin/ComponentManager.h
+++ b/source/cppexpose/include/cppexpose/plugin/ComponentManager.h
@@ -14,6 +14,7 @@ namespace cppexpose
 {
 
 
+class ComponentRegistry;
 class PluginLibrary;
 
 
@@ -47,6 +48,17 @@ class CPPEXPOSE_API ComponentManager
 {
 public:
     Signal<> componentsChanged; ///< Called when a component has been added
+
+
+public:
+    /**
+    *  @brief
+    *    Get component registry
+    *
+    *  @return
+    *    Component registry
+    */
+    static ComponentRegistry & registry();
 
 
 public:
@@ -241,8 +253,8 @@ protected:
     std::vector<std::string>                              m_pathsInternal;       ///< Plugin paths (internal)
     std::vector<std::string>                              m_pathsUser;           ///< Plugin paths (user defined)
     std::vector<AbstractComponent *>                      m_components;          ///< Available components, statically initialized once per component class via the COMPONENT macro
-    std::map<std::string, std::unique_ptr<PluginLibrary>> m_librariesByFilePath; ///< Available components by path
     std::map<std::string, AbstractComponent *>            m_componentsByName;    ///< Available components by name
+    std::map<std::string, std::unique_ptr<PluginLibrary>> m_librariesByFilePath; ///< Plugin libraries by path
 };
 
 

--- a/source/cppexpose/include/cppexpose/plugin/ComponentManager.h
+++ b/source/cppexpose/include/cppexpose/plugin/ComponentManager.h
@@ -6,6 +6,8 @@
 #include <vector>
 #include <map>
 
+#include <cpplocate/ModuleInfo.h>
+
 #include <cppexpose/signal/Signal.h>
 #include <cppexpose/plugin/ComponentHelpers.h>
 
@@ -246,6 +248,23 @@ protected:
     *    plugins must be remaining.
     */
     void unloadLibrary(PluginLibrary * library);
+
+    /**
+    *  @brief
+    *    Update components
+    *
+    *  @param[in] library
+    *    Plugin library (can be null)
+    *  @param[in] modInfo
+    *    Module information
+    *
+    *  @remarks
+    *    This function updates the component list by looking at the list
+    *    of newly registered components and adding them to the component
+    *    manager. If a library pointer is given, the found components are
+    *    considered to belong to that library.
+    */
+    void updateComponents(PluginLibrary * library = nullptr, const cpplocate::ModuleInfo & modInfo = cpplocate::ModuleInfo()) const;
 
 
 protected:

--- a/source/cppexpose/include/cppexpose/plugin/ComponentRegistry.h
+++ b/source/cppexpose/include/cppexpose/plugin/ComponentRegistry.h
@@ -1,0 +1,73 @@
+
+#pragma once
+
+
+#include <vector>
+
+#include <cppexpose/cppexpose_api.h>
+
+
+namespace cppexpose
+{
+
+
+class AbstractComponent;
+
+
+/**
+*  @brief
+*    Registry for newly registered components
+*
+*    The ComponentRegister is used to register new components.
+*    It as accessed via ComponentManager, where a single static
+*    instance of this class is created. Components register
+*    themselves at that registry when they are statically
+*    initialized. When the ComponentManager update its list of
+*    components, it also clears the component registry afterwards.
+*/
+class CPPEXPOSE_API ComponentRegistry
+{
+public:
+    /**
+    *  @brief
+    *    Constructor
+    */
+    ComponentRegistry();
+
+    /**
+    *  @brief
+    *    Destructor
+    */
+    virtual ~ComponentRegistry();
+
+    /**
+    *  @brief
+    *    Get components
+    *
+    *  @return
+    *    List of registered components
+    */
+    const std::vector<AbstractComponent *> & components() const;
+
+    /**
+    *  @brief
+    *    Add component
+    *
+    *  @param[in] component
+    *    Component (must NOT be null)
+    */
+    void addComponent(AbstractComponent * component);
+
+    /**
+    *  @brief
+    *    Clear list of components
+    */
+    void clear();
+
+
+protected:
+    std::vector<AbstractComponent *> m_components; ///< List of registered components
+};
+
+
+} // namespace cppexpose

--- a/source/cppexpose/include/cppexpose/plugin/PluginLibrary.h
+++ b/source/cppexpose/include/cppexpose/plugin/PluginLibrary.h
@@ -2,6 +2,7 @@
 #pragma once
 
 
+#include <vector>
 #include <string>
 
 #include <cppexpose/cppexpose_api.h>
@@ -16,27 +17,9 @@ class AbstractComponent;
 
 /**
 *  @brief
-*    Function to initialize a plugin library
+*    Function to get information about a plugin library
 */
-using init_ptr = void (*)();
-
-/**
-*  @brief
-*    Function to deinitialize a plugin library
-*/
-using deinit_ptr = void (*)();
-
-/**
-*  @brief
-*    Function to get the number of components contained in a library
-*/
-using numComponents_ptr = size_t (*)();
-
-/**
-*  @brief
-*    Function to get a specific component of a plugin library
-*/
-using component_ptr = cppexpose::AbstractComponent * (*)(size_t);
+using GetPluginInfoPtr = const char * (*)();
 
 
 /**
@@ -45,6 +28,9 @@ using component_ptr = cppexpose::AbstractComponent * (*)(size_t);
 */
 class CPPEXPOSE_API PluginLibrary 
 {
+    friend class ComponentManager;
+
+
 public:
     /**
     *  @brief
@@ -81,46 +67,44 @@ public:
 
     /**
     *  @brief
-    *    Initialize plugin library
-    */
-    void initialize();
-
-    /**
-    *  @brief
-    *    De-initialize plugin library
-    */
-    void deinitialize();
-
-    /**
-    *  @brief
-    *    Get number of components contained in the library
+    *    Get information about plugin library
     *
     *  @return
-    *    Number of components
+    *    Identification string from plugin library
     */
-    size_t numComponents() const;
+    const char * pluginInfo();
 
     /**
     *  @brief
-    *    Get component by index
-    *
-    *  @param[in] index
-    *    Component number
+    *    Get components that belong to the plugin library
     *
     *  @return
-    *    Pointer to the component, nullptr on error
+    *    List of components that belong to the plugin library
     */
-    cppexpose::AbstractComponent * component(size_t index) const;
+    const std::vector<AbstractComponent *> & components() const;
 
 
 protected:
-    std::string       m_filePath; ///< Path to the loaded library
-    void            * m_handle;   ///< Library handle
+    /**
+    *  @brief
+    *    Add component to library
+    *
+    *  @param[in] component
+    *    Component (must NOT be null!)
+    *
+    *  @remarks
+    *    As components register themselves automatically, this
+    *    function is called by the component manager to remember
+    *    what components belong to a plugin library.
+    */
+    void addComponent(AbstractComponent * component);
 
-    init_ptr          m_initPtr;          ///< Pointer to function init()
-    deinit_ptr        m_deinitPtr;        ///< Pointer to function deinit()
-    numComponents_ptr m_numComponentsPtr; ///< Pointer to function numComponents()
-    component_ptr     m_componentPtr;     ///< Pointer to function component()
+
+protected:
+    std::string                      m_filePath;         ///< Path to the loaded library
+    void                           * m_handle;           ///< Library handle
+    GetPluginInfoPtr                 m_getPluginInfoPtr; ///< Pointer to function getPluginInfo()
+    std::vector<AbstractComponent *> m_components;       ///< List of components that belong to the plugin library
 };
 
 

--- a/source/cppexpose/include/cppexpose/plugin/PluginLibrary.h
+++ b/source/cppexpose/include/cppexpose/plugin/PluginLibrary.h
@@ -21,6 +21,18 @@ class AbstractComponent;
 */
 using GetPluginInfoPtr = const char * (*)();
 
+/**
+*  @brief
+*    Function for initializing a plugin library
+*/
+using InitPluginPtr = void (*)();
+
+/**
+*  @brief
+*    Function for de-initializing a plugin library
+*/
+using DeInitPluginPtr = void (*)();
+
 
 /**
 *  @brief
@@ -76,6 +88,18 @@ public:
 
     /**
     *  @brief
+    *    Initialize plugin library
+    */
+    void initPlugin();
+
+    /**
+    *  @brief
+    *    De-initialize plugin library
+    */
+    void deinitPlugin();
+
+    /**
+    *  @brief
     *    Get components that belong to the plugin library
     *
     *  @return
@@ -104,6 +128,8 @@ protected:
     std::string                      m_filePath;         ///< Path to the loaded library
     void                           * m_handle;           ///< Library handle
     GetPluginInfoPtr                 m_getPluginInfoPtr; ///< Pointer to function getPluginInfo()
+    InitPluginPtr                    m_initPluginPtr;    ///< Pointer to function initPlugin()
+    DeInitPluginPtr                  m_deinitPluginPtr;  ///< Pointer to function deinitPlugin()
     std::vector<AbstractComponent *> m_components;       ///< List of components that belong to the plugin library
 };
 

--- a/source/cppexpose/include/cppexpose/plugin/plugin_api.h
+++ b/source/cppexpose/include/cppexpose/plugin/plugin_api.h
@@ -48,5 +48,13 @@
         return "cppexpose_plugin"; \
     }
 
+#define CPPEXPOSE_PLUGIN_LIBRARY_INIT \
+    extern "C" CPPEXPOSE_PLUGIN_API void initPlugin()
+
+#define CPPEXPOSE_PLUGIN_LIBRARY_DEINIT \
+    extern "C" CPPEXPOSE_PLUGIN_API void deinitPlugin()
+
+// Not needed any more, left for compatibility reasons
 #define CPPEXPOSE_PLUGIN_COMPONENT(CLASS)
+
 #define CPPEXPOSE_PLUGIN_LIBRARY_END

--- a/source/cppexpose/include/cppexpose/plugin/plugin_api.h
+++ b/source/cppexpose/include/cppexpose/plugin/plugin_api.h
@@ -4,6 +4,8 @@
 
 #include <vector>
 
+#include <cppexpose/plugin/ComponentManager.h>
+#include <cppexpose/plugin/ComponentRegistry.h>
 #include <cppexpose/plugin/Component.h>
 
 
@@ -31,6 +33,7 @@
             VENDOR, \
             VERSION) \
         { \
+            cppexpose::ComponentManager::registry().addComponent(this); \
         } \
     }; \
     \
@@ -40,31 +43,10 @@
     TYPE::ComponentType TYPE::Component;
 
 #define CPPEXPOSE_PLUGIN_LIBRARY \
-    static std::vector<cppexpose::AbstractComponent *> g_components; \
-    \
-    extern "C" CPPEXPOSE_PLUGIN_API void initialize() \
-    {
-
-#define CPPEXPOSE_PLUGIN_COMPONENT(CLASS) \
-        g_components.push_back(&CLASS::Component);
-
-#define CPPEXPOSE_PLUGIN_LIBRARY_END \
-    } \
-    \
-    extern "C" CPPEXPOSE_PLUGIN_API int numComponents() \
+    extern "C" CPPEXPOSE_PLUGIN_API const char * getPluginInfo() \
     { \
-        return (int)g_components.size(); \
-    } \
-    \
-    extern "C" CPPEXPOSE_PLUGIN_API cppexpose::AbstractComponent * component(unsigned int index) \
-    { \
-        if (index < (unsigned int)g_components.size()) \
-            return g_components[index]; \
-        \
-        return nullptr; \
-    } \
-    \
-    extern "C" CPPEXPOSE_PLUGIN_API void deinitialize() \
-    { \
-        g_components.clear(); \
+        return "cppexpose_plugin"; \
     }
+
+#define CPPEXPOSE_PLUGIN_COMPONENT(CLASS)
+#define CPPEXPOSE_PLUGIN_LIBRARY_END

--- a/source/cppexpose/source/plugin/ComponentManager.cpp
+++ b/source/cppexpose/source/plugin/ComponentManager.cpp
@@ -216,7 +216,7 @@ bool ComponentManager::loadLibrary(const std::string & filePath, bool reload)
         }
     }
 
-    // Loading failed. Destroy library object and return failure.
+    // If loading failed, destroy library object and return failure
     if (!valid)
     {
         cppassist::warning() << (alreadyLoaded ? "Reloading" : "Loading") << " plugin(s) from '" << filePath << "' failed.";
@@ -228,6 +228,9 @@ bool ComponentManager::loadLibrary(const std::string & filePath, bool reload)
     if (alreadyLoaded) {
         unloadLibrary(it->second.get());
     }
+
+    // Initialize plugin
+    library->initPlugin();
 
     // Add new components from library
     updateComponents(library.get(), modInfo);
@@ -251,6 +254,9 @@ void ComponentManager::unloadLibrary(PluginLibrary * library)
     {
         return;
     }
+
+    // De-initialize plugin
+    library->deinitPlugin();
 
     // Remove components belonging to the plugin library
     for (auto * component : library->components())

--- a/source/cppexpose/source/plugin/ComponentManager.cpp
+++ b/source/cppexpose/source/plugin/ComponentManager.cpp
@@ -176,18 +176,6 @@ AbstractComponent * ComponentManager::component(const std::string & name) const
     return it->second;
 }
 
-void ComponentManager::addComponent(AbstractComponent * component)
-{
-    // Add component to list
-    m_components.push_back(component);
-
-    // Save component by name
-    m_componentsByName[component->name()] = component;
-
-    // Emit signal
-    componentsChanged();
-}
-
 void ComponentManager::printComponents() const
 {
     // Print info about each plugin
@@ -280,6 +268,18 @@ void ComponentManager::unloadLibrary(PluginLibrary * library)
 
     // Unload plugin library
     m_librariesByFilePath.erase(it);
+}
+
+void ComponentManager::addComponent(AbstractComponent * component)
+{
+    // Add component to list
+    m_components.push_back(component);
+
+    // Save component by name
+    m_componentsByName[component->name()] = component;
+
+    // Emit signal
+    componentsChanged();
 }
 
 void ComponentManager::updateComponents(PluginLibrary * library, const cpplocate::ModuleInfo & modInfo) const

--- a/source/cppexpose/source/plugin/ComponentRegistry.cpp
+++ b/source/cppexpose/source/plugin/ComponentRegistry.cpp
@@ -1,0 +1,33 @@
+
+#include <cppexpose/plugin/ComponentRegistry.h>
+
+
+namespace cppexpose
+{
+
+
+ComponentRegistry::ComponentRegistry()
+{
+}
+
+ComponentRegistry::~ComponentRegistry()
+{
+}
+
+const std::vector<AbstractComponent *> & ComponentRegistry::components() const
+{
+    return m_components;
+}
+
+void ComponentRegistry::addComponent(AbstractComponent * component)
+{
+    m_components.push_back(component);
+}
+
+void ComponentRegistry::clear()
+{
+    m_components.clear();
+}
+
+
+} // namespace cppexpose

--- a/source/cppexpose/source/plugin/PluginLibrary.cpp
+++ b/source/cppexpose/source/plugin/PluginLibrary.cpp
@@ -52,6 +52,8 @@ PluginLibrary::PluginLibrary(const std::string & filePath)
 : m_filePath(filePath)
 , m_handle(0)
 , m_getPluginInfoPtr(nullptr)
+, m_initPluginPtr(nullptr)
+, m_deinitPluginPtr(nullptr)
 {
     // Open library
     m_handle = dlopen(filePath.c_str(), RTLD_LAZY);
@@ -64,6 +66,8 @@ PluginLibrary::PluginLibrary(const std::string & filePath)
 
     // Get pointers to exported functions
     *reinterpret_cast<void**>(&m_getPluginInfoPtr) = dlsym(m_handle, "getPluginInfo");
+    *reinterpret_cast<void**>(&m_initPluginPtr)    = dlsym(m_handle, "initPlugin");
+    *reinterpret_cast<void**>(&m_deinitPluginPtr)  = dlsym(m_handle, "deinitPlugin");
 }
 
 PluginLibrary::~PluginLibrary()
@@ -87,6 +91,22 @@ bool PluginLibrary::isValid() const
 const char * PluginLibrary::pluginInfo()
 {
     return (*m_getPluginInfoPtr)();
+}
+
+void PluginLibrary::initPlugin()
+{
+    if (m_initPluginPtr)
+    {
+        (*m_initPluginPtr)();
+    }
+}
+
+void PluginLibrary::deinitPlugin()
+{
+    if (m_deinitPluginPtr)
+    {
+        (*m_deinitPluginPtr)();
+    }
 }
 
 const std::vector<AbstractComponent *> & PluginLibrary::components() const

--- a/source/examples/example-plugins/plugin.cpp
+++ b/source/examples/example-plugins/plugin.cpp
@@ -1,4 +1,6 @@
 
+#include <iostream>
+
 #include <cppexpose/plugin/plugin_api.h>
 
 #include "HelloWorld.h"
@@ -6,6 +8,14 @@
 
 CPPEXPOSE_PLUGIN_LIBRARY
 
-    CPPEXPOSE_PLUGIN_COMPONENT(HelloWorld)
+    CPPEXPOSE_PLUGIN_LIBRARY_INIT
+    {
+        std::cout << "initializing example-plugins" << std::endl;
+    }
+
+    CPPEXPOSE_PLUGIN_LIBRARY_DEINIT
+    {
+        std::cout << "de-initializing example-plugins" << std::endl;
+    }
 
 CPPEXPOSE_PLUGIN_LIBRARY_END

--- a/source/examples/plugin/main.cpp
+++ b/source/examples/plugin/main.cpp
@@ -19,11 +19,6 @@ int main(int, char * [])
     // Create a component manager
     ComponentManager componentManager;
 
-    // Add local components
-    componentManager.addComponent(&BottlesOfBeer::Component);
-    componentManager.addComponent(&Addition::Component);
-    componentManager.addComponent(&Multiplication::Component);
-
     // Search for plugins in the current working directory
     componentManager.addPluginPath(".");
     componentManager.scanPlugins();


### PR DESCRIPTION
This PR changes the plugin system so that components automatically register themselves at the component manager. This is true for directly linked libraries as well as plugins (I changed my mind about that for the sake of simplicity). To avoid the static initialization order fiasco, the components are registered at a singleton registry which is then read by the (non-static) component manager.
