### PR TITLE
Problem: cppexpose cannot be installed to non-system directories in system-dir-install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ option(OPTION_BUILD_TESTS           "Build tests."                              
 option(OPTION_BUILD_DOCS            "Build documentation."                                   OFF)
 option(OPTION_BUILD_EXAMPLES        "Build examples."                                        OFF)
 option(OPTION_BUILD_WITH_STD_REGEX  "Use std::regex instead of Boost"                        ON)
+option(OPTION_FORCE_SYSTEM_DIR_INSTALL "Force system dir install"                            OFF)
 
 
 # 
@@ -132,7 +133,7 @@ if("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr" OR "${CMAKE_INSTALL_PREFIX}" STREQU
 endif()
 
 # Installation paths
-if(UNIX AND SYSTEM_DIR_INSTALL)
+if((UNIX AND SYSTEM_DIR_INSTALL) OR OPTION_FORCE_SYSTEM_DIR_INSTALL)
     # Install into the system (/usr/bin or /usr/local/bin)
     set(INSTALL_ROOT      "share/${project}")         # /usr/[local]/share/<project>
     set(INSTALL_CMAKE     "share/${project}/cmake")   # /usr/[local]/share/<project>/cmake


### PR DESCRIPTION
We want to package cppexpose (and others) but we cannot install it using system-dir-install into fakeroot due to auto-recognition of cppassist

Solution: add an optional override flag to do that