### PR TITLE
Fix crash in duktape backend when property value cannot be converted

### DIFF
--- a/source/cppexpose/source/scripting/DuktapeScriptBackend.cpp
+++ b/source/cppexpose/source/scripting/DuktapeScriptBackend.cpp
@@ -278,6 +278,12 @@ void DuktapeScriptBackend::pushToDukStack(const Variant & value)
             duk_put_prop_string(m_context, -2, pair.first.c_str());
         }
     }
+
+    else
+    {
+        warning() << "Unknown variant type found: " << value.type().name();
+        duk_push_undefined(m_context);
+    }
 }
 
 int DuktapeScriptBackend::getNextStashIndex()


### PR DESCRIPTION
See https://github.com/cginternals/gloperate/issues/180 for an explanation. This PR fixes only the crash by pushing `undefined` to the stack, not the actual problem in the linked issue (it should be possible to properly access GLM vectors from within a gloperate script, since these are used in many places).