### PR TITLE
Add convenience overload for Object::addProperty

### DIFF
--- a/source/cppexpose/include/cppexpose/reflection/Object.h
+++ b/source/cppexpose/include/cppexpose/reflection/Object.h
@@ -200,6 +200,29 @@ public:
 
     /**
     *  @brief
+    *    Create and add property to object
+    *
+    *  @param[in] name
+    *    Name of the new property
+    *
+    *  @param[in] arguments
+    *    Property constructor arguments
+    *
+    *  @return
+    *    'true' if the property has been added to the object, else 'false'
+    *
+    *  @remarks
+    *    Creates a property of the given type with the given arguments and adds it to the object.
+    *
+    *    The name of the property must be valid and unique to the object,
+    *    also the property must not belong to any other object already.
+    *    Otherwise, the property will not be added to the object.
+    */
+    template <typename Type, typename ... Arguments>
+    bool addProperty(const std::string & name, Arguments && ... arguments);
+
+    /**
+    *  @brief
     *    Remove property from object
     *
     *  @param[in] property

--- a/source/cppexpose/include/cppexpose/reflection/Object.inl
+++ b/source/cppexpose/include/cppexpose/reflection/Object.inl
@@ -30,6 +30,13 @@ DynamicProperty<T> * Object::createDynamicProperty(const std::string & name, con
     return propertyPtr;
 }
 
+template <typename Type, typename ... Arguments>
+bool Object::addProperty(const std::string & name, Arguments && ... arguments)
+{
+    auto property = cppassist::make_unique<Property<Type>>(name, nullptr, std::forward<Arguments>(arguments)...);
+    return addProperty(std::move(property));
+}
+
 template <typename RET, typename... Arguments>
 void Object::addFunction(const std::string & name, RET (*fn)(Arguments...))
 {


### PR DESCRIPTION
... taking constructor arguments for a new property. Simplifies this ```addProperty(std::make_unique<cppexpose::Property<...>>("myProp", nullptr, this, &MyObject::getter, &MyObject::setter));```
to this:
```addProperty<...>("myProp", this, &MyObject::getter, &MyObject::setter);```.

This function is analogous to `Object::addFunction`, which doesn't require the `make_unique...` part either.