### PR TITLE
Allow base-class member function pointers in Signal::connect

### DIFF
--- a/source/cppexpose/include/cppexpose/signal/Signal.h
+++ b/source/cppexpose/include/cppexpose/signal/Signal.h
@@ -62,8 +62,8 @@ public:
     *  @param[in] method
     *    Member function that is invoked
     */
-    template <class T>
-    Connection connect(T * object, void (T::*method)(Arguments...)) const;
+    template <class T, class U>
+    Connection connect(T * object, void (U::*method)(Arguments...)) const;
 
     /**
     *  @brief

--- a/source/cppexpose/include/cppexpose/signal/Signal.inl
+++ b/source/cppexpose/include/cppexpose/signal/Signal.inl
@@ -27,8 +27,8 @@ Connection Signal<Arguments...>::connect(Callback callback) const
 }
 
 template <typename... Arguments>
-template <class T>
-Connection Signal<Arguments...>::connect(T * object, void (T::*method)(Arguments...)) const
+template <class T, class U>
+Connection Signal<Arguments...>::connect(T * object, void (U::*method)(Arguments...)) const
 {
     return connect([object, method](Arguments... arguments)
     {


### PR DESCRIPTION
Before, this would give a compile error (no overloaded function matches argument types) on MSVC (VS 2017):
```
struct Base
{
    void myOp();
}

struct Derived : Base
{
}

Derived d;

Signal<> mySignal;
mySignal.connect(&d, &Base::myOp) // error here
```