### PR TITLE
Fixes/improvements for Duktape scripting backend

### DIFF
--- a/source/cppexpose/source/scripting/DuktapeObjectWrapper.cpp
+++ b/source/cppexpose/source/scripting/DuktapeObjectWrapper.cpp
@@ -387,19 +387,32 @@ duk_ret_t DuktapeObjectWrapper::callObjectFunction(duk_context * context)
         }
 
         // Call function
-        Variant value = func->call(arguments);
+        try
+        {
+            Variant value = func->call(arguments);
 
-        // Check return value
-        if (!value.isNull())
-        {
-            // Push return value to stack
-            scriptBackend->pushToDukStack(value);
-            return 1;
+            // Check return value
+            if (!value.isNull())
+            {
+                // Push return value to stack
+                scriptBackend->pushToDukStack(value);
+                return 1;
+            }
+            else
+            {
+                // No return value
+                return 0;
+            }
         }
-        else
+        catch (const std::exception & e)
         {
-            // No return value
-            return 0;
+            // Does not return
+            duk_error(context, DUK_ERR_EVAL_ERROR, e.what());
+        }
+        catch (...)
+        {
+            // Does not return
+            duk_error(context, DUK_ERR_EVAL_ERROR, "unknown error");
         }
     }
 

--- a/source/cppexpose/source/scripting/DuktapeScriptBackend.cpp
+++ b/source/cppexpose/source/scripting/DuktapeScriptBackend.cpp
@@ -309,8 +309,15 @@ void DuktapeScriptBackend::pushToDukStack(const Variant & value)
     else if (value.hasType<cppexpose::Object *>())
     {
         const auto object = value.value<cppexpose::Object *>();
-        const auto objWrapper = getOrCreateObjectWrapper(object);
-        objWrapper->pushToDukStack();
+        if (object == nullptr)
+        {
+            duk_push_null(m_context);
+        }
+        else
+        {
+            const auto objWrapper = getOrCreateObjectWrapper(object);
+            objWrapper->pushToDukStack();
+        }
     }
 
     else


### PR DESCRIPTION
Provides two minor things:
1. Fix crash when pushing nullptr (to Object) to the stack
2. Throw JS-error when trying to set a read-only property